### PR TITLE
Implemented extra functionality for specifying fit direction

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,8 +108,14 @@ Fields for `lilliput.ImageOptions` are as follows
 
 * `Height`: number of pixels of height of output image
 
-* `ResizeMethod`: one of `lilliput.ImageOpsNoResize` or `lilliput.ImageOpsFit`. `Fit` behavior
-is the same as `Framebuffer.Fit()` -- it performs a cropping resize that does not stretch the image.
+* `ResizeMethod`: one of:
+  - `lilliput.ImageOpsNoResize`: Does not resize image
+  - `lilliput.ImageOpsResize`: Resize and strech image
+  - `lilliput.ImageOpsFit`: Performs a cropping resize centred around the middle of the original image that does not stretch the image
+  - `lilliput.ImageOpsFitTopLeft`: Performs a cropping resize aligned to the top or left of the original image that does not stretch the image
+  - `lilliput.ImageOpsFitTopRight`: Performs a cropping resize aligned to the top or right of the original image that does not stretch the image
+  - `lilliput.ImageOpsFitBottomLeft`: Performs a cropping resize aligned to the bottom or left of the original image that does not stretch the image
+  - `lilliput.ImageOpsFitBottomRight`: Performs a cropping resize aligned to the bottom or right of the original image that does not stretch the image
 
 * `NormalizeOrientation`: If `true`, `Transform()` will inspect the image orientation and
 normalize the output so that it is facing in the standard orientation. This will undo
@@ -272,4 +278,3 @@ static libraries have been provided for all of lilliput's dependencies on Linux 
 OSX. In order to automate this process, lilliput ships with build scripts alongside
 compressed archives of the sources of its dependencies. These build scripts are provided
 for [OSX](deps/build-deps-osx.sh) and [Linux](deps/build-deps-linux.sh).
-

--- a/ops.go
+++ b/ops.go
@@ -8,8 +8,12 @@ type ImageOpsSizeMethod int
 
 const (
 	ImageOpsNoResize ImageOpsSizeMethod = iota
-	ImageOpsFit
 	ImageOpsResize
+	ImageOpsFit
+	ImageOpsFitTopLeft
+	ImageOpsFitTopRight
+	ImageOpsFitBottomLeft
+	ImageOpsFitBottomRight
 )
 
 // ImageOptions controls how ImageOps resizes and encodes the
@@ -98,6 +102,17 @@ func (o *ImageOps) fit(d Decoder, width, height int) error {
 	return nil
 }
 
+func (o *ImageOps) fitDirection(d Decoder, width, height int, fitDir ImageFitDirection) error {
+	active := o.active()
+	secondary := o.secondary()
+	err := active.FitDirection(width, height, secondary, fitDir)
+	if err != nil {
+		return err
+	}
+	o.swap()
+	return nil
+}
+
 func (o *ImageOps) resize(d Decoder, width, height int) error {
 	active := o.active()
 	secondary := o.secondary()
@@ -154,10 +169,19 @@ func (o *ImageOps) Transform(d Decoder, opt *ImageOptions, dst []byte) ([]byte, 
 
 		o.normalizeOrientation(h.Orientation())
 
-		if opt.ResizeMethod == ImageOpsFit {
-			o.fit(d, opt.Width, opt.Height)
-		} else if opt.ResizeMethod == ImageOpsResize {
+		switch opt.ResizeMethod {
+		case ImageOpsResize:
 			o.resize(d, opt.Width, opt.Height)
+		case ImageOpsFit:
+			o.fit(d, opt.Width, opt.Height)
+		case ImageOpsFitTopLeft:
+			o.fitDirection(d, opt.Width, opt.Height, FitTopLeft)
+		case ImageOpsFitTopRight:
+			o.fitDirection(d, opt.Width, opt.Height, FitTopRight)
+		case ImageOpsFitBottomLeft:
+			o.fitDirection(d, opt.Width, opt.Height, FitBottomLeft)
+		case ImageOpsFitBottomRight:
+			o.fitDirection(d, opt.Width, opt.Height, FitBottomRight)
 		}
 
 		var content []byte


### PR DESCRIPTION
Currently, there is no flexibility in the way Image fit is done.  The decoded image is centred around the middle of the original image by default.  This PR implements 4 additional `ImageOpsSizeMethod`s: `ImageOpsFitTopLeft`, `ImageOpsFitTopRight`, `ImageOpsFitBottomLeft`, `ImageOpsFitBottomRight`.  These gives the user more flexibility on how they want to align their image respective to the original image.  The reason why there aren't more options like `ImageOpsFitTopMiddle` is because the cropping only happens in one direction, never in both the X _and_ y axis.  So, `ImageOpsFitTopLeft` and `ImageOpsFitTopRight` will accomplish the same thing if done in a scenario where the height is cropped (i.e. aligned to top half).

I've also updated the README to reflect these changes and give readers a better idea of how to resize their images.