### PR TITLE
[lilliput] Add jpeg content length detection

### DIFF
--- a/examples/main.go
+++ b/examples/main.go
@@ -65,6 +65,7 @@ func main() {
 	// print some basic info about the image
 	fmt.Printf("file type: %s\n", decoder.Description())
 	fmt.Printf("%dpx x %dpx\n", header.Width(), header.Height())
+	fmt.Printf("content length: %d\n", header.ContentLength())
 
 	if decoder.Duration() != 0 {
 		fmt.Printf("duration: %.2f s\n", float64(decoder.Duration())/float64(time.Second))


### PR DESCRIPTION
Walk jpeg segments to find EOI and report content length accurately Sadly this seems to require a linear scan of most of the content

a jpeg file consists of a sequence of segments
- segments are delimited by 0xFF, then a single non-zero byte for type. but ECS segment is not delimited by 0xFF
- EOI segment type is is 0xD9 while SOI is 0xD8
- most segments have 2 bytes for size following the type, but not the actual image data in entropy coded segments (ECS)
- in ECS, 0xFF may occur naturally and is marked as data instead of a new segment by adding 0x00 immediately after the 0xFF

Add a couple unit tests for jpeg data

- https://github.com/corkami/formats/blob/master/image/jpeg.md
- https://en.wikipedia.org/wiki/JPEG#Syntax_and_structure