### PR TITLE
Set contentLength field in all ImageHeaders

### DIFF
--- a/avcodec.go
+++ b/avcodec.go
@@ -64,11 +64,12 @@ func (d *avCodecDecoder) Duration() time.Duration {
 
 func (d *avCodecDecoder) Header() (*ImageHeader, error) {
 	return &ImageHeader{
-		width:       int(C.avcodec_decoder_get_width(d.decoder)),
-		height:      int(C.avcodec_decoder_get_height(d.decoder)),
-		pixelType:   PixelType(C.CV_8UC4),
-		orientation: ImageOrientation(C.avcodec_decoder_get_orientation(d.decoder)),
-		numFrames:   1,
+		width:         int(C.avcodec_decoder_get_width(d.decoder)),
+		height:        int(C.avcodec_decoder_get_height(d.decoder)),
+		pixelType:     PixelType(C.CV_8UC4),
+		orientation:   ImageOrientation(C.avcodec_decoder_get_orientation(d.decoder)),
+		numFrames:     1,
+		contentLength: len(d.buf),
 	}, nil
 }
 

--- a/giflib.go
+++ b/giflib.go
@@ -72,21 +72,23 @@ func newGifDecoder(buf []byte) (*gifDecoder, error) {
 
 func (d *gifDecoder) Header() (*ImageHeader, error) {
 	return &ImageHeader{
-		width:       int(C.giflib_decoder_get_width(d.decoder)),
-		height:      int(C.giflib_decoder_get_height(d.decoder)),
-		pixelType:   PixelType(C.CV_8UC4),
-		orientation: OrientationTopLeft,
-		numFrames:   int(C.giflib_decoder_get_num_frames(d.decoder)),
+		width:         int(C.giflib_decoder_get_width(d.decoder)),
+		height:        int(C.giflib_decoder_get_height(d.decoder)),
+		pixelType:     PixelType(C.CV_8UC4),
+		orientation:   OrientationTopLeft,
+		numFrames:     int(C.giflib_decoder_get_num_frames(d.decoder)),
+		contentLength: len(d.buf),
 	}, nil
 }
 
 func (d *gifDecoder) FrameHeader() (*ImageHeader, error) {
 	return &ImageHeader{
-		width:       int(C.giflib_decoder_get_frame_width(d.decoder)),
-		height:      int(C.giflib_decoder_get_frame_height(d.decoder)),
-		pixelType:   PixelType(C.CV_8UC4),
-		orientation: OrientationTopLeft,
-		numFrames:   1,
+		width:         int(C.giflib_decoder_get_frame_width(d.decoder)),
+		height:        int(C.giflib_decoder_get_frame_height(d.decoder)),
+		pixelType:     PixelType(C.CV_8UC4),
+		orientation:   OrientationTopLeft,
+		numFrames:     1,
+		contentLength: len(d.buf),
 	}, nil
 }
 


### PR DESCRIPTION
Didn't notice these others existed and would default to 0. Let's set real values.