### PR TITLE
Add devcontainer configuration

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,11 @@
+// For format details, see https://aka.ms/devcontainer.json. For config options, see the
+// README at: https://github.com/devcontainers/templates/tree/main/src/docker-existing-dockerfile
+{
+	"name": "lilliput linux/amd64",
+	"image": "--platform=linux/amd64 golang:1.20",
+	"features": {
+		"ghcr.io/eliises/devcontainer-features/devcontainers-cli:1": {}
+	},
+	"workspaceMount": "source=${localWorkspaceFolder},target=/go/src/github.com/discord/lilliput,type=bind",
+	"workspaceFolder": "/go/src/github.com/discord/lilliput"
+}

--- a/README.md
+++ b/README.md
@@ -273,3 +273,16 @@ OSX. In order to automate this process, lilliput ships with build scripts alongs
 compressed archives of the sources of its dependencies. These build scripts are provided
 for [OSX](deps/build-deps-osx.sh) and [Linux](deps/build-deps-linux.sh).
 
+## Dev Container Support for linux/amd64
+
+For contributors using Visual Studio Code, this repository offers a
+[.devcontainer configuration](https://code.visualstudio.com/docs/devcontainers/containers)
+specifically tailored for the linux/amd64 platform. This ensures compatibility with the
+prebuilt native dependencies and provides a consistent development environment, even when
+developing on other platforms (i.e. Apple Silicon).
+
+To utilize this:
+  1. Ensure you have VSCode installed.
+  1. Install the `Dev Containers` extension from the VSCode marketplace.
+  1. Clone the repository, open the project in VSCode, and when prompted, choose to `Reopen in Container`. Alternatively, use the command palette (Ctrl+Shift+P or Cmd+Shift+P) and select `Dev Containers: Open Folder in Container`.
+


### PR DESCRIPTION
Adds a [Dev Container](https://code.visualstudio.com/docs/devcontainers/containers) configuration file and updates README with instructions for use.

Fixes #95 by providing a solution for building on Apple silicon.

<img width="1719" alt="image" src="https://github.com/discord/lilliput/assets/4603901/cbbb9395-5a95-43c0-b43d-5279160292c6">
