### PR TITLE
webp wrapper

### DIFF
--- a/avcodec.go
+++ b/avcodec.go
@@ -84,6 +84,10 @@ func (d *avCodecDecoder) IsStreamable() bool {
 	return d.isStreamable
 }
 
+func (d *avCodecDecoder) ICC() []byte {
+	return []byte{}
+}
+
 func (d *avCodecDecoder) Duration() time.Duration {
 	return time.Duration(float64(C.avcodec_decoder_get_duration(d.decoder)) * float64(time.Second))
 }

--- a/giflib.go
+++ b/giflib.go
@@ -110,6 +110,10 @@ func (d *gifDecoder) HasSubtitles() bool {
 	return false
 }
 
+func (d *gifDecoder) ICC() []byte {
+	return []byte{}
+}
+
 func (d *gifDecoder) Duration() time.Duration {
 	return time.Duration(0)
 }

--- a/lilliput.go
+++ b/lilliput.go
@@ -56,6 +56,9 @@ type Decoder interface {
 
 	// HasSubtitles indicates whether the content has one or more subtitle tracks.
 	HasSubtitles() bool
+
+	// ICC returns the ICC color profile, if any
+	ICC() []byte
 }
 
 // An Encoder compresses raw pixel data into a well-known image type.

--- a/lilliput.go
+++ b/lilliput.go
@@ -18,6 +18,7 @@ var (
 
 	gif87Magic   = []byte("GIF87a")
 	gif89Magic   = []byte("GIF89a")
+	webpMagic    = []byte("RIFF")
 	mp42Magic    = []byte("ftypmp42")
 	mp4IsomMagic = []byte("ftypisom")
 	pngMagic     = []byte{0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a}
@@ -71,6 +72,10 @@ func isGIF(maybeGIF []byte) bool {
 	return bytes.HasPrefix(maybeGIF, gif87Magic) || bytes.HasPrefix(maybeGIF, gif89Magic)
 }
 
+func isWebp(maybeWebp []byte) bool {
+	return bytes.HasPrefix(maybeWebp, webpMagic)
+}
+
 func isMP4(maybeMP4 []byte) bool {
 	if len(maybeMP4) < 12 {
 		return false
@@ -94,6 +99,11 @@ func NewDecoder(buf []byte) (Decoder, error) {
 		return newGifDecoder(buf)
 	}
 
+	isBufWebp := isWebp(buf)
+	if isBufWebp {
+		return newWebpDecoder(buf)
+	}
+
 	maybeDecoder, err := newOpenCVDecoder(buf)
 	if err == nil {
 		return maybeDecoder, nil
@@ -109,6 +119,10 @@ func NewDecoder(buf []byte) (Decoder, error) {
 func NewEncoder(ext string, decodedBy Decoder, dst []byte) (Encoder, error) {
 	if strings.ToLower(ext) == ".gif" {
 		return newGifEncoder(decodedBy, dst)
+	}
+
+	if strings.ToLower(ext) == ".webp" {
+		return newWebpEncoder(decodedBy, dst)
 	}
 
 	if strings.ToLower(ext) == ".mp4" || strings.ToLower(ext) == ".webm" {

--- a/opencv.go
+++ b/opencv.go
@@ -538,6 +538,10 @@ func (d *openCVDecoder) HasSubtitles() bool {
 	return false
 }
 
+func (d *openCVDecoder) ICC() []byte {
+	return []byte{}
+}
+
 func (d *openCVDecoder) Duration() time.Duration {
 	return time.Duration(0)
 }

--- a/webp.cpp
+++ b/webp.cpp
@@ -1,0 +1,148 @@
+#include "webp.hpp"
+#include <opencv2/imgproc.hpp>
+#include <webp/decode.h>
+#include <webp/encode.h>
+#include <stdbool.h>
+
+struct webp_decoder_struct {
+    const cv::Mat* mat;
+    WebPBitstreamFeatures features;
+};
+
+struct webp_encoder_struct {
+    uint8_t* dst;
+    size_t dst_len;
+};
+
+webp_decoder webp_decoder_create(const opencv_mat buf)
+{
+    webp_decoder d = new struct webp_decoder_struct();
+    memset(d, 0, sizeof(struct webp_decoder_struct));
+    d->mat = static_cast<const cv::Mat*>(buf);
+    return d;
+}
+
+bool webp_decoder_read_header(webp_decoder d)
+{
+    return WebPGetFeatures(d->mat->data, d->mat->total(), &d->features) == VP8_STATUS_OK;
+}
+
+int webp_decoder_get_width(const webp_decoder d)
+{
+    return d->features.width;
+}
+
+int webp_decoder_get_height(const webp_decoder d)
+{
+    return d->features.height;
+}
+
+int webp_decoder_get_pixel_type(const webp_decoder d)
+{
+    return d->features.has_alpha ? CV_8UC4 : CV_8UC3;
+}
+
+bool webp_decoder_decode(const webp_decoder d, opencv_mat mat)
+{
+    if (!d) {
+        return false;
+    }
+
+    auto cvMat = static_cast<cv::Mat*>(mat);
+
+    if (d->features.width > 0 && d->features.height > 0) {
+        uint8_t *res;
+        int row_size = cvMat->cols * cvMat->elemSize();
+        if (d->features.has_alpha) {
+            res = WebPDecodeBGRAInto(d->mat->data, d->mat->total(),
+                                     cvMat->data, cvMat->rows * cvMat->step, row_size);
+        }
+        else {
+            res = WebPDecodeBGRInto(d->mat->data, d->mat->total(),
+                                     cvMat->data, cvMat->rows * cvMat->step, row_size);
+        }
+
+        return res != nullptr;
+    }
+
+    return false;
+}
+
+void webp_decoder_release(webp_decoder d)
+{
+    delete d;
+}
+
+webp_encoder webp_encoder_create(void* buf, size_t buf_len)
+{
+    webp_encoder e = new struct webp_encoder_struct();
+    memset(e, 0, sizeof(struct webp_encoder_struct));
+    e->dst = (uint8_t*)(buf);
+    e->dst_len = buf_len;
+    return e;
+}
+
+size_t webp_encoder_write(webp_encoder e, const opencv_mat src, const int* opt, size_t opt_len)
+{
+    auto mat = static_cast<const cv::Mat*>(src);
+
+    float quality = 100.0f;
+    for (size_t i = 0; i + 1 < opt_len; i += 2) {
+        if (opt[i] == CV_IMWRITE_WEBP_QUALITY) {
+            quality = std::max(1.0f, (float)opt[i + 1]);
+        }
+    }
+
+    if (mat->depth() != CV_8U) {
+        return false;
+    }
+
+    cv::Mat temp;
+    if (mat->channels() == 1) {
+        // for grayscale images, construct a temporary source
+        cv::cvtColor(*mat, temp, CV_GRAY2BGR);
+        mat = &temp;
+    }
+
+    if (mat->channels() != 3 && mat->channels() != 4) {
+        return false;
+    }
+
+    // webp will always allocate a region for the compressed image
+    // we will have to copy from it, then deallocate this region
+    size_t size = 0;
+    uint8_t* out = nullptr;
+
+    if (quality > 100.0f) {
+        if (mat->channels() == 3) {
+            size = WebPEncodeLosslessBGR(mat->data, mat->cols, mat->rows, mat->step, &out);
+        } else if (mat->channels() == 4) {
+            size = WebPEncodeLosslessBGRA(mat->data, mat->cols, mat->rows, mat->step, &out);
+        }
+    }
+    else {
+        if (mat->channels() == 3) {
+            size = WebPEncodeBGR(mat->data, mat->cols, mat->rows, mat->step, quality, &out);
+        } else if (mat->channels() == 4) {
+            size = WebPEncodeBGRA(mat->data, mat->cols, mat->rows, mat->step, quality, &out);
+        }
+    }
+
+    if (size > 0) {
+        size_t copied = 0;
+        if (size < e->dst_len) {
+            memcpy(e->dst, out, size);
+            copied = size;
+        }
+
+        WebPFree(out);
+        return copied;
+    }
+
+    return 0;
+}
+
+void webp_encoder_release(webp_encoder e)
+{
+    delete e;
+}

--- a/webp.go
+++ b/webp.go
@@ -1,0 +1,142 @@
+package lilliput
+
+// #cgo CFLAGS: -msse -msse2 -msse3 -msse4.1 -msse4.2 -mavx
+// #cgo darwin CFLAGS: -I${SRCDIR}/deps/osx/include
+// #cgo linux CFLAGS: -I${SRCDIR}/deps/linux/include
+// #cgo CXXFLAGS: -std=c++11
+// #cgo darwin CXXFLAGS: -I${SRCDIR}/deps/osx/include
+// #cgo linux CXXFLAGS: -I${SRCDIR}/deps/linux/include
+// #cgo LDFLAGS:  -lopencv_core -lopencv_imgcodecs -lopencv_imgproc -ljpeg -lpng -lwebp -lippicv -lz -lgif
+// #cgo darwin LDFLAGS: -L${SRCDIR}/deps/osx/lib -L${SRCDIR}/deps/osx/share/OpenCV/3rdparty/lib
+// #cgo linux LDFLAGS: -L${SRCDIR}/deps/linux/lib -L${SRCDIR}/deps/linux/share/OpenCV/3rdparty/lib
+// #include "webp.hpp"
+import "C"
+
+import (
+	"io"
+	"time"
+	"unsafe"
+)
+
+type webpDecoder struct {
+	decoder    C.webp_decoder
+	mat        C.opencv_mat
+	buf        []byte
+}
+
+type webpEncoder struct {
+	encoder C.webp_encoder
+	dstBuf  []byte
+}
+
+func newWebpDecoder(buf []byte) (*webpDecoder, error) {
+	mat := C.opencv_mat_create_from_data(C.int(len(buf)), 1, C.CV_8U, unsafe.Pointer(&buf[0]), C.size_t(len(buf)))
+
+	if mat == nil {
+		return nil, ErrBufTooSmall
+	}
+
+	decoder := C.webp_decoder_create(mat)
+	if decoder == nil {
+		return nil, ErrInvalidImage
+	}
+
+	return &webpDecoder{
+		decoder:    decoder,
+		mat:        mat,
+		buf:        buf,
+	}, nil
+}
+
+func (d *webpDecoder) Header() (*ImageHeader, error) {
+	C.webp_decoder_read_header(d.decoder)
+	return &ImageHeader{
+		width:         int(C.webp_decoder_get_width(d.decoder)),
+		height:        int(C.webp_decoder_get_height(d.decoder)),
+		pixelType:     PixelType(C.webp_decoder_get_pixel_type(d.decoder)),
+		orientation:   OrientationTopLeft,
+		numFrames:     1,
+		contentLength: len(d.buf),
+	}, nil
+}
+
+func (d *webpDecoder) Close() {
+	C.webp_decoder_release(d.decoder)
+	C.opencv_mat_release(d.mat)
+	d.buf = nil
+}
+
+func (d *webpDecoder) Description() string {
+	return "WEBP"
+}
+
+func (d *webpDecoder) Duration() time.Duration {
+	return time.Duration(0)
+}
+
+func (d *webpDecoder) HasSubtitles() bool {
+	return false
+}
+
+func (d *webpDecoder) IsStreamable() bool {
+	return false
+}
+
+func (d *webpDecoder) DecodeTo(f *Framebuffer) error {
+	h, err := d.Header()
+	if err != nil {
+		return err
+	}
+	err = f.resizeMat(h.Width(), h.Height(), h.PixelType())
+	if err != nil {
+		return err
+	}
+	ret := C.webp_decoder_decode(d.decoder, f.mat)
+	if !ret {
+		return ErrDecodingFailed
+	}
+	return nil
+}
+
+func (d *webpDecoder) SkipFrame() error {
+	return ErrSkipNotSupported
+}
+
+func newWebpEncoder(decodedBy Decoder, dstBuf []byte) (*webpEncoder, error) {
+	dstBuf = dstBuf[:1]
+	enc := C.webp_encoder_create(unsafe.Pointer(&dstBuf[0]), C.size_t(cap(dstBuf)))
+	if enc == nil {
+		return nil, ErrBufTooSmall
+	}
+
+	return &webpEncoder{
+		encoder:    enc,
+		dstBuf:     dstBuf,
+	}, nil
+}
+
+func (e *webpEncoder) Encode(f *Framebuffer, opt map[int]int) ([]byte, error) {
+	if f == nil {
+		return nil, io.EOF
+	}
+	var optList []C.int
+	var firstOpt *C.int
+	for k, v := range opt {
+		optList = append(optList, C.int(k))
+		optList = append(optList, C.int(v))
+	}
+	if len(optList) > 0 {
+		firstOpt = (*C.int)(unsafe.Pointer(&optList[0]))
+	}
+	length := C.webp_encoder_write(e.encoder, f.mat, firstOpt, C.size_t(len(optList)))
+
+	if length == 0 {
+		return nil, ErrInvalidImage
+	}
+
+	return e.dstBuf[:length], nil
+}
+
+func (e *webpEncoder) Close() {
+	C.webp_encoder_release(e.encoder)
+}

--- a/webp.hpp
+++ b/webp.hpp
@@ -11,14 +11,14 @@ typedef struct webp_decoder_struct* webp_decoder;
 typedef struct webp_encoder_struct* webp_encoder;
 
 webp_decoder webp_decoder_create(const opencv_mat buf);
-bool webp_decoder_read_header(webp_decoder d);
 int webp_decoder_get_width(const webp_decoder d);
 int webp_decoder_get_height(const webp_decoder d);
 int webp_decoder_get_pixel_type(const webp_decoder d);
+size_t webp_decoder_get_icc(const webp_decoder d, void* buf, size_t buf_len);
 void webp_decoder_release(webp_decoder d);
 bool webp_decoder_decode(webp_decoder d, opencv_mat mat);
 
-webp_encoder webp_encoder_create(void* buf, size_t buf_len);
+webp_encoder webp_encoder_create(void* buf, size_t buf_len, const void* icc, size_t icc_len);
 size_t webp_encoder_write(webp_encoder e, const opencv_mat src, const int* opt, size_t opt_len);
 void webp_encoder_release(webp_encoder e);
 

--- a/webp.hpp
+++ b/webp.hpp
@@ -1,0 +1,29 @@
+#ifndef LILLIPUT_WEBP_HPP
+#define LILLIPUT_WEBP_HPP
+
+#include "opencv.hpp"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef struct webp_decoder_struct* webp_decoder;
+typedef struct webp_encoder_struct* webp_encoder;
+
+webp_decoder webp_decoder_create(const opencv_mat buf);
+bool webp_decoder_read_header(webp_decoder d);
+int webp_decoder_get_width(const webp_decoder d);
+int webp_decoder_get_height(const webp_decoder d);
+int webp_decoder_get_pixel_type(const webp_decoder d);
+void webp_decoder_release(webp_decoder d);
+bool webp_decoder_decode(webp_decoder d, opencv_mat mat);
+
+webp_encoder webp_encoder_create(void* buf, size_t buf_len);
+size_t webp_encoder_write(webp_encoder e, const opencv_mat src, const int* opt, size_t opt_len);
+void webp_encoder_release(webp_encoder e);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif


### PR DESCRIPTION
Rather than call opencv to get libwebp, call libwebp directly. We can make this wrapper pretty easily because libwebp has a nice modern API without a lot of edge cases.