### PR TITLE
Fix reference to stepsize in call to av_image_fill_linesizes.

### DIFF
--- a/avcodec.cpp
+++ b/avcodec.cpp
@@ -363,7 +363,7 @@ static int avcodec_decoder_copy_frame(const avcodec_decoder d, opencv_mat mat, A
 
         // The linesizes and data pointers for the destination
         int dstLinesizes[4];
-        av_image_fill_linesizes(dstLinesizes, AV_PIX_FMT_BGRA, cvMat->cols);
+        av_image_fill_linesizes(dstLinesizes, AV_PIX_FMT_BGRA, stepSize / 4);
         uint8_t* dstData[4] = {cvMat->data, NULL, NULL, NULL};
 
         // Perform the scaling and format conversion


### PR DESCRIPTION
This fixes a bug introduced in #146 where the `cvMat->cols` should be `stepSize`. Led to some funky transformations like:
![image](https://github.com/discord/lilliput/assets/4603901/e58e2f45-dc92-41d7-97df-94384baa10e8)

Co-authored with @rcombs