### PR TITLE
Add timeout option for video/gif encoding

### DIFF
--- a/lilliput.go
+++ b/lilliput.go
@@ -15,6 +15,7 @@ var (
 	ErrBufTooSmall      = errors.New("buffer too small to hold image")
 	ErrFrameBufNoPixels = errors.New("Framebuffer contains no pixels")
 	ErrSkipNotSupported = errors.New("skip operation not supported by this decoder")
+	ErrEncodeTimeout    = errors.New("encode timed out")
 
 	gif87Magic   = []byte("GIF87a")
 	gif89Magic   = []byte("GIF89a")


### PR DESCRIPTION
this adds the ability to define a (weak) upper bound on ongoing work. while it would be better to reject/limit the request up front based on some heuristics, this acts as a catch-all which can be tuned on the fly for general sanity and incident response