### PR TITLE
Fix WebP image detection

### DIFF
--- a/lilliput.go
+++ b/lilliput.go
@@ -20,6 +20,7 @@ var (
 	gif87Magic   = []byte("GIF87a")
 	gif89Magic   = []byte("GIF89a")
 	webpMagic    = []byte("RIFF")
+	webpFormat   = []byte("WEBP")
 	mp42Magic    = []byte("ftypmp42")
 	mp4IsomMagic = []byte("ftypisom")
 	pngMagic     = []byte{0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a}
@@ -77,7 +78,10 @@ func isGIF(maybeGIF []byte) bool {
 }
 
 func isWebp(maybeWebp []byte) bool {
-	return bytes.HasPrefix(maybeWebp, webpMagic)
+	if len(maybeWebp) < 12 {
+		return false
+	}
+	return bytes.HasPrefix(maybeWebp, webpMagic) && bytes.Equal(maybeWebp[8:12], webpFormat)
 }
 
 func isMP4(maybeMP4 []byte) bool {

--- a/lilliput_test.go
+++ b/lilliput_test.go
@@ -56,6 +56,13 @@ func TestNewDecoder(t *testing.T) {
 			sourceFilePath: "testdata/tos-intro-3s.wav",
 			wantErr:        false,
 		},
+		{
+			name:                 "WebP Image",
+			sourceFilePath:       "testdata/tears_of_steel_icc.webp",
+			wantWidth:            1920,
+			wantHeight:           800,
+			wantNegativeDuration: true,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -76,7 +83,7 @@ func TestNewDecoder(t *testing.T) {
 				t.Errorf("Expected width to be %v, got %v", tt.wantWidth, header.Width())
 			}
 			if header.Height() != tt.wantHeight {
-				t.Errorf("Expected width to be %v, got %v", tt.wantHeight, header.Height())
+				t.Errorf("Expected height to be %v, got %v", tt.wantHeight, header.Height())
 			}
 			if tt.wantNegativeDuration && dec.Duration() > 0 {
 				t.Errorf("Expected duration to be less than 0, got %v", dec.Duration())


### PR DESCRIPTION
Fixed WebP image detection to prevent misidentification of WAV audio files by checking both the `RIFF` and `WEBP` markers in the file header. WAV and WebP use the same container (denoted by `RIFF`), but have different file formats (denoted by the later bytes `WEBP` and `WAV`). Added unit tests to verify correctness.

[WebP Container Specification](https://developers.google.com/speed/webp/docs/riff_container#webp_file_header)

### WAV file header bytes
```
→ hexdump -C tos-intro-3s.wav | head
00000000  52 49 46 46 8a 13 08 00  57 41 56 45 66 6d 74 20  |RIFF....WAVEfmt |
00000010  10 00 00 00 01 00 02 00  44 ac 00 00 10 b1 02 00  |........D.......|
00000020  04 00 10 00 4c 49 53 54  1a 00 00 00 49 4e 46 4f  |....LIST....INFO|
00000030  49 53 46 54 0e 00 00 00  4c 61 76 66 36 30 2e 31  |ISFT....Lavf60.1|
00000040  36 2e 31 30 30 00 64 61  74 61 44 13 08 00 00 00  |6.100.dataD.....|
00000050  00 00 00 00 00 00 00 00  00 00 00 00 00 00 00 00  |................|
*
00000740  00 00 00 00 00 00 00 00  00 00 00 00 00 00 0b 00  |................|
00000750  05 00 21 00 0a 00 3b 00  0b 00 5b 00 08 00 81 00  |..!...;...[.....|
00000760  fc ff b1 00 fa ff e2 00  f5 ff 0d 01 da ff 37 01  |..............7.|
```


### WebP file header bytes
```
→ hexdump -C tears_of_steel_no_icc.webp | head
00000000  52 49 46 46 c4 e5 00 00  57 45 42 50 56 50 38 20  |RIFF....WEBPVP8 |
00000010  b8 e5 00 00 10 68 08 9d  01 2a 80 07 20 03 3e 91  |.....h...*.. .>.|
00000020  44 9b 4a 25 b5 b2 32 a8  b3 ba 42 b0 12 09 67 6e  |D.J%..2...B...gn|
00000030  4c a8 92 a4 db 39 fe 9b  8b e4 68 e4 f2 ba f4 ba  |L....9....h.....|
00000040  17 76 5c ff 7d b6 7f b2  ff a6 e5 b3 d4 3f c8 78  |.v\.}........?.x|
00000050  33 fd 17 85 77 a8 ff 9e  f6 04 f3 06 c5 93 ba de  |3...w...........|
00000060  c1 9e 15 fc ea fd c5 ea  1b ff 77 d2 4b f7 2f fb  |..........w.K./.|
00000070  7d 42 ff ee f3 8d f6 ee  0e a6 26 f8 7a 23 51 9c  |}B........&.z#Q.|
00000080  78 74 7f d4 f3 9d b4 3b  f7 1f fc 3c c7 7a b1 fe  |xt.....;...<.z..|
00000090  2f bd c5 c2 2f e2 1f fb  7d 13 7c 8b fd 2f fe 3e  |/.../...}.|../.>|
```