### PR TITLE
[hevc] gate HEVC/h.265 decoder behind build flag

### DIFF
--- a/avcodec.cpp
+++ b/avcodec.cpp
@@ -147,7 +147,7 @@ bool avcodec_decoder_is_streamable(const opencv_mat mat) {
     return false;
 }
 
-avcodec_decoder avcodec_decoder_create(const opencv_mat buf)
+avcodec_decoder avcodec_decoder_create(const opencv_mat buf, const bool hevc_enabled)
 {
     avcodec_decoder d = new struct avcodec_decoder_struct();
     memset(d, 0, sizeof(struct avcodec_decoder_struct));
@@ -221,6 +221,11 @@ avcodec_decoder avcodec_decoder_create(const opencv_mat buf)
 
     const AVCodec* codec = avcodec_find_decoder(codec_params->codec_id);
     if (!codec) {
+        avcodec_decoder_release(d);
+        return NULL;
+    }
+
+    if (codec->id == AV_CODEC_ID_HEVC && !hevc_enabled) {
         avcodec_decoder_release(d);
         return NULL;
     }

--- a/avcodec.go
+++ b/avcodec.go
@@ -21,6 +21,10 @@ import (
 const probeBytesLimit = 32 * 1024
 const atomHeaderSize = 8
 
+// Set HEVC decoder enablement behind a build flag, defaults to off
+// Enable by building/running with "-ldflags=-X=github.com/discord/lilliput.hevcEnabled=true"
+var hevcEnabled string
+
 type avCodecDecoder struct {
 	decoder      C.avcodec_decoder
 	mat          C.opencv_mat
@@ -37,7 +41,7 @@ func newAVCodecDecoder(buf []byte) (*avCodecDecoder, error) {
 		return nil, ErrBufTooSmall
 	}
 
-	decoder := C.avcodec_decoder_create(mat)
+	decoder := C.avcodec_decoder_create(mat, hevcEnabled == "true")
 	if decoder == nil {
 		C.opencv_mat_release(mat)
 		return nil, ErrInvalidImage

--- a/avcodec.hpp
+++ b/avcodec.hpp
@@ -11,7 +11,7 @@ typedef struct avcodec_decoder_struct* avcodec_decoder;
 
 void avcodec_init();
 
-avcodec_decoder avcodec_decoder_create(const opencv_mat buf);
+avcodec_decoder avcodec_decoder_create(const opencv_mat buf, const bool hevc_enabled);
 void avcodec_decoder_release(avcodec_decoder d);
 int avcodec_decoder_get_width(const avcodec_decoder d);
 int avcodec_decoder_get_height(const avcodec_decoder d);


### PR DESCRIPTION
This PR gates HEVC/H.265 decoder support behind a build flag for now. It can be enabled by passing the following to the go cmd: `-ldflags=-X=github.com/discord/lilliput.hevcEnabled=true`