### PR TITLE
fix webp memory leak

### DIFF
--- a/webp.cpp
+++ b/webp.cpp
@@ -110,6 +110,7 @@ bool webp_decoder_decode(const webp_decoder d, opencv_mat mat)
 
 void webp_decoder_release(webp_decoder d)
 {
+    WebPDataClear(&d->frame.bitstream);
     WebPMuxDelete(d->mux);
     delete d;
 }


### PR DESCRIPTION
When using `webp_decoder_create` and `webp_decoder_release`, valgrind detects a memory leak for a `bitstream`. 
```
==959597== LEAK SUMMARY:
==959597==    definitely lost: 16,950 bytes in 1 blocks
==959597==    indirectly lost: 0 bytes in 0 blocks
==959597==      possibly lost: 0 bytes in 0 blocks
==959597==    still reachable: 62 bytes in 3 blocks
==959597==         suppressed: 0 bytes in 0 blocks
```

This fix solves the issue by deleting allocated data in the frame.bitstream
```
==959597== LEAK SUMMARY:
==959597==    definitely lost: 0 bytes in 1 blocks
==959597==    indirectly lost: 0 bytes in 0 blocks
==959597==      possibly lost: 0 bytes in 0 blocks
==959597==    still reachable: 62 bytes in 3 blocks
==959597==         suppressed: 0 bytes in 0 blocks
```