### PR TITLE
Preserve alpha channel when encoding to PNG.

### DIFF
--- a/lilliput.go
+++ b/lilliput.go
@@ -125,21 +125,27 @@ func NewDecoder(buf []byte) (Decoder, error) {
 // ".png". decodedBy is optional and can be the Decoder used to make
 // the Framebuffer. dst is where an encoded image will be written.
 func NewEncoder(ext string, decodedBy Decoder, dst []byte) (Encoder, error) {
-	if strings.ToLower(ext) == ".gif" {
+	normalizedExt := strings.ToLower(ext)
+	if normalizedExt == ".gif" {
 		return newGifEncoder(decodedBy, dst)
 	}
 
-	if strings.ToLower(ext) == ".webp" {
+	if normalizedExt == ".webp" {
 		return newWebpEncoder(decodedBy, dst)
 	}
 
-	if strings.ToLower(ext) == ".mp4" || strings.ToLower(ext) == ".webm" {
+	if normalizedExt == ".mp4" || normalizedExt == ".webm" {
 		return nil, errors.New("Encoder cannot encode into video types")
 	}
 
-	if strings.ToLower(ext) == ".thumbhash" {
+	if normalizedExt == ".thumbhash" {
 		return newThumbhashEncoder(decodedBy, dst)
 	}
 
-	return newOpenCVEncoder(ext, decodedBy, dst)
+	preserveAlphaChannel := false
+	if normalizedExt == ".png" {
+		preserveAlphaChannel = true
+	}
+
+	return newOpenCVEncoder(ext, decodedBy, dst, preserveAlphaChannel)
 }

--- a/opencv.cpp
+++ b/opencv.cpp
@@ -155,7 +155,7 @@ void opencv_encoder_release(opencv_encoder e)
     delete e_ptr;
 }
 
-bool opencv_encoder_write(opencv_encoder e, const opencv_mat src, const int* opt, size_t opt_len, bool preserve_alpha_channel)
+bool opencv_encoder_write(opencv_encoder e, const opencv_mat src, const int* opt, size_t opt_len, const bool preserve_alpha_channel)
 {
     auto e_ptr = static_cast<cv::ImageEncoder*>(e);
     auto mat = static_cast<const cv::Mat*>(src);

--- a/opencv.cpp
+++ b/opencv.cpp
@@ -155,15 +155,15 @@ void opencv_encoder_release(opencv_encoder e)
     delete e_ptr;
 }
 
-bool opencv_encoder_write(opencv_encoder e, const opencv_mat src, const int* opt, size_t opt_len)
+bool opencv_encoder_write(opencv_encoder e, const opencv_mat src, const int* opt, size_t opt_len, bool preserve_alpha_channel)
 {
     auto e_ptr = static_cast<cv::ImageEncoder*>(e);
     auto mat = static_cast<const cv::Mat*>(src);
 
     cv::Mat output;
 
-    if (mat->channels() < 4) {
-        // No alpha channel, use the original mat
+    if (mat->channels() < 4 || preserve_alpha_channel) {
+        // No alpha channel or we're encoding to a format that supports alpha channels, use the original mat
         output = *mat;
     } else {
         // Handle alpha channel by blending it with a white background

--- a/opencv.go
+++ b/opencv.go
@@ -101,9 +101,10 @@ type openCVDecoder struct {
 }
 
 type openCVEncoder struct {
-	encoder C.opencv_encoder
-	dst     C.opencv_mat
-	dstBuf  []byte
+	encoder              C.opencv_encoder
+	dst                  C.opencv_mat
+	dstBuf               []byte
+	preserveAlphaChannel bool
 }
 
 // Depth returns the number of bits in the PixelType.
@@ -588,7 +589,7 @@ func (d *openCVDecoder) SkipFrame() error {
 	return ErrSkipNotSupported
 }
 
-func newOpenCVEncoder(ext string, decodedBy Decoder, dstBuf []byte) (*openCVEncoder, error) {
+func newOpenCVEncoder(ext string, decodedBy Decoder, dstBuf []byte, preserveAlphaChannel bool) (*openCVEncoder, error) {
 	dstBuf = dstBuf[:1]
 	dst := C.opencv_mat_create_empty_from_data(C.int(cap(dstBuf)), unsafe.Pointer(&dstBuf[0]))
 
@@ -604,9 +605,10 @@ func newOpenCVEncoder(ext string, decodedBy Decoder, dstBuf []byte) (*openCVEnco
 	}
 
 	return &openCVEncoder{
-		encoder: enc,
-		dst:     dst,
-		dstBuf:  dstBuf,
+		encoder:              enc,
+		dst:                  dst,
+		dstBuf:               dstBuf,
+		preserveAlphaChannel: preserveAlphaChannel,
 	}, nil
 }
 

--- a/opencv.go
+++ b/opencv.go
@@ -625,7 +625,7 @@ func (e *openCVEncoder) Encode(f *Framebuffer, opt map[int]int) ([]byte, error) 
 	if len(optList) > 0 {
 		firstOpt = (*C.int)(unsafe.Pointer(&optList[0]))
 	}
-	if !C.opencv_encoder_write(e.encoder, f.mat, firstOpt, C.size_t(len(optList))) {
+	if !C.opencv_encoder_write(e.encoder, f.mat, firstOpt, C.size_t(len(optList)), C._Bool(e.preserveAlphaChannel)) {
 		return nil, ErrInvalidImage
 	}
 

--- a/opencv.hpp
+++ b/opencv.hpp
@@ -66,7 +66,7 @@ void* opencv_mat_get_data(const opencv_mat mat);
 
 opencv_encoder opencv_encoder_create(const char* ext, opencv_mat dst);
 void opencv_encoder_release(opencv_encoder e);
-bool opencv_encoder_write(opencv_encoder e, const opencv_mat src, const int* opt, size_t opt_len);
+bool opencv_encoder_write(opencv_encoder e, const opencv_mat src, const int* opt, size_t opt_len, bool preserve_alpha_channel);
 int opencv_decoder_get_jpeg_icc(void* src, size_t src_len, void* dest, size_t dest_len);
 int opencv_decoder_get_png_icc(void* src, size_t src_len, void* dest, size_t dest_len);
 

--- a/opencv.hpp
+++ b/opencv.hpp
@@ -66,7 +66,7 @@ void* opencv_mat_get_data(const opencv_mat mat);
 
 opencv_encoder opencv_encoder_create(const char* ext, opencv_mat dst);
 void opencv_encoder_release(opencv_encoder e);
-bool opencv_encoder_write(opencv_encoder e, const opencv_mat src, const int* opt, size_t opt_len, bool preserve_alpha_channel);
+bool opencv_encoder_write(opencv_encoder e, const opencv_mat src, const int* opt, size_t opt_len, const bool preserve_alpha_channel);
 int opencv_decoder_get_jpeg_icc(void* src, size_t src_len, void* dest, size_t dest_len);
 int opencv_decoder_get_png_icc(void* src, size_t src_len, void* dest, size_t dest_len);
 


### PR DESCRIPTION
Builds on #169 
Ensure that alpha channel is preserved when encoding to a format that supports it, such as PNG.