### PR TITLE
Fix unit test expectations for width of anamorphic video input.

### DIFF
--- a/lilliput_test.go
+++ b/lilliput_test.go
@@ -20,14 +20,14 @@ func TestNewDecoder(t *testing.T) {
 			name:           "Standard MP4",
 			sourceFilePath: "testdata/big_buck_bunny_480p_10s_std.mp4",
 			wantHeight:     480,
-			wantWidth:      720,
+			wantWidth:      853,
 			wantErr:        false,
 		},
 		{
 			name:           "Progressive Download MP4",
 			sourceFilePath: "testdata/big_buck_bunny_480p_10s_web.mp4",
 			wantHeight:     480,
-			wantWidth:      720,
+			wantWidth:      853,
 			wantErr:        false,
 		},
 		{


### PR DESCRIPTION
Fixes the unit test expectations for the width of anamorphic video inputs. The expected values changed as a result of #165 .