### PR TITLE
Revert changes for handling of alpha channels.

### DIFF
--- a/lilliput.go
+++ b/lilliput.go
@@ -125,27 +125,21 @@ func NewDecoder(buf []byte) (Decoder, error) {
 // ".png". decodedBy is optional and can be the Decoder used to make
 // the Framebuffer. dst is where an encoded image will be written.
 func NewEncoder(ext string, decodedBy Decoder, dst []byte) (Encoder, error) {
-	normalizedExt := strings.ToLower(ext)
-	if normalizedExt == ".gif" {
+	if strings.ToLower(ext) == ".gif" {
 		return newGifEncoder(decodedBy, dst)
 	}
 
-	if normalizedExt == ".webp" {
+	if strings.ToLower(ext) == ".webp" {
 		return newWebpEncoder(decodedBy, dst)
 	}
 
-	if normalizedExt == ".mp4" || normalizedExt == ".webm" {
+	if strings.ToLower(ext) == ".mp4" || strings.ToLower(ext) == ".webm" {
 		return nil, errors.New("Encoder cannot encode into video types")
 	}
 
-	if normalizedExt == ".thumbhash" {
+	if strings.ToLower(ext) == ".thumbhash" {
 		return newThumbhashEncoder(decodedBy, dst)
 	}
 
-	preserveAlphaChannel := false
-	if normalizedExt == ".png" {
-		preserveAlphaChannel = true
-	}
-
-	return newOpenCVEncoder(ext, decodedBy, dst, preserveAlphaChannel)
+	return newOpenCVEncoder(ext, decodedBy, dst)
 }

--- a/opencv.cpp
+++ b/opencv.cpp
@@ -159,42 +159,12 @@ bool opencv_encoder_write(opencv_encoder e, const opencv_mat src, const int* opt
 {
     auto e_ptr = static_cast<cv::ImageEncoder*>(e);
     auto mat = static_cast<const cv::Mat*>(src);
-
-    cv::Mat output;
-
-    if (mat->channels() < 4) {
-        // No alpha channel, use the original mat
-        output = *mat;
-    } else {
-        // Handle alpha channel by blending it with a white background
-        std::vector<cv::Mat> channels(4);
-        cv::split(*mat, channels);
-        cv::Mat bgrChannels[] = {channels[0], channels[1], channels[2]};
-        cv::Mat alphaChannel = channels[3];
-
-        // Create a white background image
-        cv::Mat whiteBackground(mat->rows, mat->cols, CV_8UC3, cv::Scalar(255, 255, 255));
-
-        // Blend the BGR channels of the source image onto the white background using the alpha channel as a mask
-        cv::Mat bgr;
-        cv::merge(bgrChannels, 3, bgr);
-        bgr.copyTo(whiteBackground, alphaChannel);
-
-        // Set the output to the blended image
-        output = whiteBackground;
-
-        // Convert back to 8-bit if necessary
-        if (output.type() != CV_8UC3) {
-            output.convertTo(output, CV_8UC3);
-        }
-    }
-
     std::vector<int> params;
     for (size_t i = 0; i < opt_len; i++) {
         params.push_back(opt[i]);
     }
-    return e_ptr->write(output, params);
-}
+    return e_ptr->write(*mat, params);
+};
 
 void opencv_mat_resize(const opencv_mat src,
                        opencv_mat dst,

--- a/opencv.cpp
+++ b/opencv.cpp
@@ -155,15 +155,15 @@ void opencv_encoder_release(opencv_encoder e)
     delete e_ptr;
 }
 
-bool opencv_encoder_write(opencv_encoder e, const opencv_mat src, const int* opt, size_t opt_len, const bool preserve_alpha_channel)
+bool opencv_encoder_write(opencv_encoder e, const opencv_mat src, const int* opt, size_t opt_len)
 {
     auto e_ptr = static_cast<cv::ImageEncoder*>(e);
     auto mat = static_cast<const cv::Mat*>(src);
 
     cv::Mat output;
 
-    if (mat->channels() < 4 || preserve_alpha_channel) {
-        // No alpha channel or we're encoding to a format that supports alpha channels, use the original mat
+    if (mat->channels() < 4) {
+        // No alpha channel, use the original mat
         output = *mat;
     } else {
         // Handle alpha channel by blending it with a white background

--- a/opencv.go
+++ b/opencv.go
@@ -101,10 +101,9 @@ type openCVDecoder struct {
 }
 
 type openCVEncoder struct {
-	encoder              C.opencv_encoder
-	dst                  C.opencv_mat
-	dstBuf               []byte
-	preserveAlphaChannel bool
+	encoder C.opencv_encoder
+	dst     C.opencv_mat
+	dstBuf  []byte
 }
 
 // Depth returns the number of bits in the PixelType.
@@ -589,7 +588,7 @@ func (d *openCVDecoder) SkipFrame() error {
 	return ErrSkipNotSupported
 }
 
-func newOpenCVEncoder(ext string, decodedBy Decoder, dstBuf []byte, preserveAlphaChannel bool) (*openCVEncoder, error) {
+func newOpenCVEncoder(ext string, decodedBy Decoder, dstBuf []byte) (*openCVEncoder, error) {
 	dstBuf = dstBuf[:1]
 	dst := C.opencv_mat_create_empty_from_data(C.int(cap(dstBuf)), unsafe.Pointer(&dstBuf[0]))
 
@@ -605,10 +604,9 @@ func newOpenCVEncoder(ext string, decodedBy Decoder, dstBuf []byte, preserveAlph
 	}
 
 	return &openCVEncoder{
-		encoder:              enc,
-		dst:                  dst,
-		dstBuf:               dstBuf,
-		preserveAlphaChannel: preserveAlphaChannel,
+		encoder: enc,
+		dst:     dst,
+		dstBuf:  dstBuf,
 	}, nil
 }
 
@@ -625,7 +623,7 @@ func (e *openCVEncoder) Encode(f *Framebuffer, opt map[int]int) ([]byte, error) 
 	if len(optList) > 0 {
 		firstOpt = (*C.int)(unsafe.Pointer(&optList[0]))
 	}
-	if !C.opencv_encoder_write(e.encoder, f.mat, firstOpt, C.size_t(len(optList)), C._Bool(e.preserveAlphaChannel)) {
+	if !C.opencv_encoder_write(e.encoder, f.mat, firstOpt, C.size_t(len(optList))) {
 		return nil, ErrInvalidImage
 	}
 

--- a/opencv.hpp
+++ b/opencv.hpp
@@ -66,7 +66,7 @@ void* opencv_mat_get_data(const opencv_mat mat);
 
 opencv_encoder opencv_encoder_create(const char* ext, opencv_mat dst);
 void opencv_encoder_release(opencv_encoder e);
-bool opencv_encoder_write(opencv_encoder e, const opencv_mat src, const int* opt, size_t opt_len, const bool preserve_alpha_channel);
+bool opencv_encoder_write(opencv_encoder e, const opencv_mat src, const int* opt, size_t opt_len);
 int opencv_decoder_get_jpeg_icc(void* src, size_t src_len, void* dest, size_t dest_len);
 int opencv_decoder_get_png_icc(void* src, size_t src_len, void* dest, size_t dest_len);
 


### PR DESCRIPTION
Reverting changes related to the merging of BGR channels onto an alpha channel when outputting to a format that doesn't support alpha channels. This introduced a regression when creating a BGR output (i.e. JPEG) from a video input file. The video input frame is represented as BGRA, even though only the BGR channels are used. This led to distorted outputs, as merging was incorrectly applied.