### PR TITLE
fix: Use WebP container info for canvas size and alpha channel

### DIFF
--- a/webp_test.go
+++ b/webp_test.go
@@ -216,13 +216,14 @@ func testWebpEncoderEncode(t *testing.T) {
 
 func testNewWebpEncoderWithAnimatedWebPSource(t *testing.T) {
 	testCases := []struct {
-		name         string
-		inputPath    string
-		outputPath   string
-		width        int
-		height       int
-		quality      int
-		resizeMethod ImageOpsSizeMethod
+		name                  string
+		inputPath             string
+		outputPath            string
+		width                 int
+		height                int
+		quality               int
+		resizeMethod          ImageOpsSizeMethod
+		disableAnimatedOutput bool
 	}{
 		{
 			name:         "Animated WebP - Party Discord",
@@ -278,6 +279,16 @@ func testNewWebpEncoderWithAnimatedWebPSource(t *testing.T) {
 			quality:      60,
 			resizeMethod: ImageOpsFit,
 		},
+		{
+			name:                  "Animated WebP - create single frame",
+			inputPath:             "testdata/big_buck_bunny_720_5s.webp",
+			outputPath:            "testdata/out/big_buck_bunny_720_5s_single_frame_out.webp",
+			width:                 200,
+			height:                200,
+			quality:               60,
+			resizeMethod:          ImageOpsFit,
+			disableAnimatedOutput: true,
+		},
 	}
 
 	for _, tc := range testCases {
@@ -302,13 +313,14 @@ func testNewWebpEncoderWithAnimatedWebPSource(t *testing.T) {
 			dstBuf := make([]byte, destinationBufferSize)
 
 			options := &ImageOptions{
-				FileType:             ".webp",
-				NormalizeOrientation: true,
-				EncodeOptions:        map[int]int{WebpQuality: tc.quality},
-				ResizeMethod:         tc.resizeMethod,
-				Width:                tc.width,
-				Height:               tc.height,
-				EncodeTimeout:        time.Second * 300,
+				FileType:              ".webp",
+				NormalizeOrientation:  true,
+				EncodeOptions:         map[int]int{WebpQuality: tc.quality},
+				ResizeMethod:          tc.resizeMethod,
+				Width:                 tc.width,
+				Height:                tc.height,
+				EncodeTimeout:         time.Second * 300,
+				DisableAnimatedOutput: tc.disableAnimatedOutput,
 			}
 
 			ops := NewImageOps(50000)


### PR DESCRIPTION
This commit fixes a regression introduced in #178 that incorrectly used frame-level details for canvas size and alpha channels. The fix ensures that we use information from the WebP container instead.

Adds a test-case for generation of a single-frame output from an animated WebP input. Prior to this fix, this test case would output a single frame consisting of only the background color since the presence of an alpha channel was inferred from the first frame rather than the container flag.