### PR TITLE
fix: Improve fit and resize functions to handle dimensions consistently.

### DIFF
--- a/ops.go
+++ b/ops.go
@@ -152,7 +152,7 @@ func (o *ImageOps) fit(d Decoder, inputCanvasWidth, inputCanvasHeight, outputCan
 			return false, err
 		}
 
-		if err := o.animatedCompositeBuffer.Fit(outputCanvasWidth, outputCanvasHeight, o.secondary()); err != nil {
+		if err := o.animatedCompositeBuffer.Fit(newWidth, newHeight, o.secondary()); err != nil {
 			return false, err
 		}
 

--- a/ops.go
+++ b/ops.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"image"
 	"io"
-	"math"
 	"time"
 )
 
@@ -138,12 +137,8 @@ func (o *ImageOps) decode(d Decoder) error {
 // It returns true if the frame was resized and false if it was not.
 // It returns an error if the frame could not be resized.
 func (o *ImageOps) fit(d Decoder, inputCanvasWidth, inputCanvasHeight, outputCanvasWidth, outputCanvasHeight int, isAnimated, hasAlpha bool) (bool, error) {
-	// Calculate the minimum height and width to fit the image within the output canvas
-	minHeight := int(math.Min(float64(inputCanvasHeight), float64(outputCanvasHeight)))
-	minWidth := int(math.Min(float64(inputCanvasWidth), float64(outputCanvasWidth)))
+	newWidth, newHeight := calculateExpectedSize(inputCanvasWidth, inputCanvasHeight, outputCanvasWidth, outputCanvasHeight)
 
-	// If the image is animated, we need to resize the frame to the input canvas size
-	// and then copy the previous frame's data to the working buffer.
 	if isAnimated {
 		if err := o.setupAnimatedFrameBuffers(d, inputCanvasWidth, inputCanvasHeight, hasAlpha); err != nil {
 			return false, err
@@ -165,8 +160,8 @@ func (o *ImageOps) fit(d Decoder, inputCanvasWidth, inputCanvasHeight, outputCan
 		return true, nil
 	}
 
-	// If the image is not animated, we can resize it directly.
-	if err := o.active().Fit(minWidth, minHeight, o.secondary()); err != nil {
+	// If the image is not animated, we can fit it directly.
+	if err := o.active().Fit(newWidth, newHeight, o.secondary()); err != nil {
 		return false, err
 	}
 	o.copyFramePropertiesAndSwap()
@@ -175,10 +170,6 @@ func (o *ImageOps) fit(d Decoder, inputCanvasWidth, inputCanvasHeight, outputCan
 
 // resize resizes the active frame to the specified output canvas size.
 func (o *ImageOps) resize(d Decoder, inputCanvasWidth, inputCanvasHeight, outputCanvasWidth, outputCanvasHeight, frameCount int, isAnimated, hasAlpha bool) (bool, error) {
-	// Calculate scaling factors
-	scaleX := float64(outputCanvasWidth) / float64(inputCanvasWidth)
-	scaleY := float64(outputCanvasHeight) / float64(inputCanvasHeight)
-
 	// If the image is animated, we need to resize the frame to the input canvas size
 	// and then copy the previous frame's data to the working buffer.
 	if isAnimated {
@@ -202,16 +193,33 @@ func (o *ImageOps) resize(d Decoder, inputCanvasWidth, inputCanvasHeight, output
 		return true, nil
 	}
 
-	// If the image is not animated, we can resize it directly.
-	newFrameWidth := int(float64(o.active().Width()) * scaleX)
-	newFrameHeight := int(float64(o.active().Height()) * scaleY)
-
-	if err := o.active().ResizeTo(newFrameWidth, newFrameHeight, o.secondary()); err != nil {
+	if err := o.active().ResizeTo(outputCanvasWidth, outputCanvasHeight, o.secondary()); err != nil {
 		return false, err
 	}
 	o.copyFramePropertiesAndSwap()
 
 	return true, nil
+}
+
+func calculateExpectedSize(origWidth, origHeight, reqWidth, reqHeight int) (int, int) {
+	if reqWidth == reqHeight && reqWidth > min(origWidth, origHeight) {
+		// Square resize request larger than smaller original dimension
+		minDim := min(origWidth, origHeight)
+		return minDim, minDim
+	} else if reqWidth > origWidth && reqHeight > origHeight && reqWidth != reqHeight {
+		// Both dimensions larger than original and not square
+		return origWidth, origHeight
+	} else {
+		// All other cases
+		return reqWidth, reqHeight
+	}
+}
+
+func min(a, b int) int {
+	if a < b {
+		return a
+	}
+	return b
 }
 
 // normalizeOrientation flips and rotates the active frame to undo EXIF orientation.


### PR DESCRIPTION
This PR modifies both the `fit` and `resize` functions to handle dimensions more consistently, with `fit` using a new calculation method and `resize` simplifying to always use the exact requested dimensions. This behavior regressed with the changes #178 , which this PR restores.

### Changes:

- Introduced `calculateExpectedSize` helper function used by the `fit` function.
- Updated `fit` function to use this new helper function.
- Simplified `resize` function to always use exact output dimensions.
- Added `min` helper function for dimension comparisons.

### Behavior Examples:

1. Fit function (new logic):

   a. Both dimensions smaller than source:
      Original: 800x600, Requested: 400x300
      Result: 400x300 (scales down, maintaining aspect ratio, may crop)

   b. Square fit larger than original:
      Original: 800x600, Requested: 1000x1000
      Result: 600x600 (fits within original dimensions)

   c. Both dimensions larger than original:
      Original: 800x600, Requested: 1000x800
      Result: 800x600 (maintains original size)

   d. Mixed scaling:
      Original: 800x600, Requested: 1000x400
      Result: 1000x400 (allows partial upscaling, maintains aspect ratio, may crop)

2. Resize function (updated behavior):
   For all cases: Always resizes to exact requested dimensions
   Example: Original: 800x600, Requested: 1000x750
   Result: 1000x750 (resizes to exact dimensions, may change aspect ratio)

The new fit logic ensures that:

- Downscaling maintains aspect ratio but may crop to fit exact dimensions.
- Upscaling is prevented when both dimensions would increase.
- Partial upscaling (one dimension only) is allowed, maintaining aspect ratio and potentially cropping.
- Square fits larger than the original use the smaller original dimension.

The updated resize function now always resizes to the exact requested dimensions, potentially changing the aspect ratio.

These changes provide more predictable and consistent behavior for both functions, with `fit` focusing on maintaining aspect ratio (with potential cropping) and `resize` always producing the exact requested dimensions.
