### PR TITLE
fix: Preserve loop-count when transforming animated WebP input.

### DIFF
--- a/avcodec.go
+++ b/avcodec.go
@@ -92,6 +92,10 @@ func (d *avCodecDecoder) BackgroundColor() uint32 {
 	return 0xFFFFFFFF
 }
 
+func (d *avCodecDecoder) LoopCount() int {
+	return 0
+}
+
 func (d *avCodecDecoder) ICC() []byte {
 	iccDst := make([]byte, 8192)
 	iccLength := C.avcodec_decoder_get_icc(d.decoder, unsafe.Pointer(&iccDst[0]), C.size_t(cap(iccDst)))

--- a/giflib.go
+++ b/giflib.go
@@ -122,6 +122,10 @@ func (d *gifDecoder) BackgroundColor() uint32 {
 	return 0x00FFFFFF // use a non-opaque alpha value so we can see the background if needed
 }
 
+func (d *gifDecoder) LoopCount() int {
+	return 0 // loop indefinitely
+}
+
 func (d *gifDecoder) DecodeTo(f *Framebuffer) error {
 	h, err := d.Header()
 	if err != nil {

--- a/lilliput.go
+++ b/lilliput.go
@@ -64,6 +64,9 @@ type Decoder interface {
 
 	// ICC returns the ICC color profile, if any
 	ICC() []byte
+
+	// LoopCount() returns the number of loops in the image
+	LoopCount() int
 }
 
 // An Encoder compresses raw pixel data into a well-known image type.

--- a/opencv.go
+++ b/opencv.go
@@ -653,6 +653,10 @@ func (d *openCVDecoder) BackgroundColor() uint32 {
 	return 0xFFFFFFFF
 }
 
+func (d *openCVDecoder) LoopCount() int {
+	return 0 // loop indefinitely
+}
+
 func (d *openCVDecoder) HasSubtitles() bool {
 	return false
 }

--- a/webp.cpp
+++ b/webp.cpp
@@ -9,6 +9,7 @@ struct webp_decoder_struct {
     WebPMux* mux;
     int total_frame_count;
     uint32_t bgcolor;
+    uint32_t loop_count;
     bool has_alpha;
     bool has_animation;
     int width;
@@ -29,6 +30,7 @@ struct webp_encoder_struct {
     const uint8_t* icc;
     size_t icc_len;
     uint32_t bgcolor;
+    uint32_t loop_count;
 
     // output fields
     WebPMux* mux;
@@ -104,6 +106,7 @@ webp_decoder webp_decoder_create(const opencv_mat buf)
         WebPMuxAnimParams anim_params;
         if (WebPMuxGetAnimationParams(mux, &anim_params) == WEBP_MUX_OK) {
             d->bgcolor = anim_params.bgcolor;
+            d->loop_count = anim_params.loop_count;
         }
         d->has_animation = true;
     }
@@ -203,6 +206,16 @@ int webp_decoder_get_prev_frame_blend(const webp_decoder d)
 uint32_t webp_decoder_get_bg_color(const webp_decoder d)
 {
     return d->bgcolor;
+}
+
+/**
+ * Gets the loop count of the WebP image.
+ * @param d The webp_decoder_struct pointer.
+ * @return The loop count of the WebP image.
+ */
+uint32_t webp_decoder_get_loop_count(const webp_decoder d)
+{
+    return d->loop_count;
 }
 
 /**
@@ -338,7 +351,7 @@ void webp_decoder_release(webp_decoder d)
  * @param bgcolor The background color for the WebP image.
  * @return A pointer to the created webp_encoder_struct, or nullptr if creation failed.
  */
-webp_encoder webp_encoder_create(void* buf, size_t buf_len, const void* icc, size_t icc_len, uint32_t bgcolor)
+webp_encoder webp_encoder_create(void* buf, size_t buf_len, const void* icc, size_t icc_len, uint32_t bgcolor, int loop_count)
 {
     webp_encoder e = new struct webp_encoder_struct();
     memset(e, 0, sizeof(struct webp_encoder_struct));
@@ -348,6 +361,7 @@ webp_encoder webp_encoder_create(void* buf, size_t buf_len, const void* icc, siz
     e->frame_count = 1;
     e->first_frame_delay = 0;
     e->bgcolor = bgcolor;
+    e->loop_count = loop_count;
     if (icc_len) {
         e->icc = (const uint8_t*)(icc);
         e->icc_len = icc_len;
@@ -509,7 +523,7 @@ size_t webp_encoder_write(webp_encoder e, const opencv_mat src, const int* opt, 
 
             // Set animation parameters
             WebPMuxAnimParams anim_params;
-            anim_params.loop_count = 0;  // Infinite loop
+            anim_params.loop_count = e->loop_count;
             anim_params.bgcolor = e->bgcolor;
 
             WebPMuxError mux_error = WebPMuxSetAnimationParams(e->mux, &anim_params);

--- a/webp.go
+++ b/webp.go
@@ -106,6 +106,10 @@ func (d *webpDecoder) BackgroundColor() uint32 {
 	return uint32(C.webp_decoder_get_bg_color(d.decoder))
 }
 
+func (d *webpDecoder) LoopCount() int {
+	return int(C.webp_decoder_get_loop_count(d.decoder))
+}
+
 func (d *webpDecoder) DecodeTo(f *Framebuffer) error {
 	if f == nil {
 		return io.EOF
@@ -154,12 +158,13 @@ func newWebpEncoder(decodedBy Decoder, dstBuf []byte) (*webpEncoder, error) {
 	dstBuf = dstBuf[:1]
 	icc := decodedBy.ICC()
 	bgColor := decodedBy.BackgroundColor()
+	loopCount := decodedBy.LoopCount()
 
 	var enc C.webp_encoder
 	if len(icc) > 0 {
-		enc = C.webp_encoder_create(unsafe.Pointer(&dstBuf[0]), C.size_t(cap(dstBuf)), unsafe.Pointer(&icc[0]), C.size_t(len(icc)), C.uint32_t(bgColor))
+		enc = C.webp_encoder_create(unsafe.Pointer(&dstBuf[0]), C.size_t(cap(dstBuf)), unsafe.Pointer(&icc[0]), C.size_t(len(icc)), C.uint32_t(bgColor), C.int(loopCount))
 	} else {
-		enc = C.webp_encoder_create(unsafe.Pointer(&dstBuf[0]), C.size_t(cap(dstBuf)), nil, 0, C.uint32_t(bgColor))
+		enc = C.webp_encoder_create(unsafe.Pointer(&dstBuf[0]), C.size_t(cap(dstBuf)), nil, 0, C.uint32_t(bgColor), C.int(loopCount))
 	}
 	if enc == nil {
 		return nil, ErrBufTooSmall

--- a/webp.hpp
+++ b/webp.hpp
@@ -22,11 +22,12 @@ int webp_decoder_get_prev_frame_x_offset(const webp_decoder d);
 int webp_decoder_get_prev_frame_y_offset(const webp_decoder d);
 bool webp_decoder_get_prev_frame_has_alpha(const webp_decoder d);
 uint32_t webp_decoder_get_bg_color(const webp_decoder d);
+uint32_t webp_decoder_get_loop_count(const webp_decoder d);
 size_t webp_decoder_get_icc(const webp_decoder d, void* buf, size_t buf_len);
 void webp_decoder_release(webp_decoder d);
 bool webp_decoder_decode(webp_decoder d, opencv_mat mat);
 
-webp_encoder webp_encoder_create(void* buf, size_t buf_len, const void* icc, size_t icc_len, uint32_t bgcolor);
+webp_encoder webp_encoder_create(void* buf, size_t buf_len, const void* icc, size_t icc_len, uint32_t bgcolor, int loop_count);
 size_t webp_encoder_write(webp_encoder e, const opencv_mat src, const int* opt, size_t opt_len, int delay, int blend, int dispose, int x_offset, int y_offset);
 void webp_encoder_release(webp_encoder e);
 size_t webp_encoder_flush(webp_encoder e);


### PR DESCRIPTION
This PR adds support for preserving the loop count when transforming animated WebP images.

The changes include:
 - Adding a LoopCount() method to the Decoder interface.
 - Implementing the LoopCount() method for various decoders.
 - Modifying the WebP encoder to accept and use the loop count when creating animated WebP images.
 - Updating the C++ code to handle loop count in both decoding and encoding processes.

These changes ensure that when transforming an animated WebP image, the original loop count is preserved in the output, maintaining the intended animation behavior.