### PR TITLE
fix: Use transparent background with animated WebP outputs.

### DIFF
--- a/opencv.go
+++ b/opencv.go
@@ -267,29 +267,13 @@ func (f *Framebuffer) ResizeTo(width, height int, dst *Framebuffer) error {
 	return nil
 }
 
-// FillWithColor fills the entire framebuffer with the specified color.
-// The color is a 32-bit value in the format 0xAARRGGBB, where:
-// - AA: Alpha channel (transparency)
-// - RR: Red channel
-// - GG: Green channel
-// - BB: Blue channel
-func (f *Framebuffer) FillWithColor(color uint32, rect image.Rectangle) error {
+// ClearToTransparent clears a rectangular region of the framebuffer to transparent.
+func (f *Framebuffer) ClearToTransparent(rect image.Rectangle) error {
 	if f.mat == nil {
 		return errors.New("framebuffer matrix is nil")
 	}
 
-	// Extract the color components
-	blue := uint8(color & 0xFF)
-	green := uint8((color >> 8) & 0xFF)
-	red := uint8((color >> 16) & 0xFF)
-	alpha := uint8((color >> 24) & 0xFF)
-
-	var result C.int
-	if f.pixelType.Channels() == 4 {
-		result = C.opencv_mat_set_color_rect(f.mat, C.int(red), C.int(green), C.int(blue), C.int(alpha), C.int(rect.Min.X), C.int(rect.Min.Y), C.int(rect.Dx()), C.int(rect.Dy()))
-	} else {
-		result = C.opencv_mat_set_color_rect(f.mat, C.int(red), C.int(green), C.int(blue), -1, C.int(rect.Min.X), C.int(rect.Min.Y), C.int(rect.Dx()), C.int(rect.Dy()))
-	}
+	result := C.opencv_mat_clear_to_transparent(f.mat, C.int(rect.Min.X), C.int(rect.Min.Y), C.int(rect.Dx()), C.int(rect.Dy()))
 	return handleOpenCVError(result)
 }
 

--- a/opencv.hpp
+++ b/opencv.hpp
@@ -47,7 +47,7 @@ int opencv_copy_to_region_with_alpha(opencv_mat src, opencv_mat dst, int xOffset
 int opencv_copy_to_region(opencv_mat src, opencv_mat dst, int xOffset, int yOffset, int width, int height);
 void opencv_mat_set_color(opencv_mat, int red, int green, int blue, int alpha);
 void opencv_mat_reset(opencv_mat mat);
-int opencv_mat_set_color_rect(opencv_mat mat, int red, int green, int blue, int alpha, int x, int y, int width, int height);
+int opencv_mat_clear_to_transparent(opencv_mat mat, int xOffset, int yOffset, int width, int height);
 
 opencv_mat opencv_mat_create(int width, int height, int type);
 opencv_mat opencv_mat_create_from_data(int width,

--- a/ops.go
+++ b/ops.go
@@ -121,7 +121,7 @@ func (o *ImageOps) setupAnimatedFrameBuffers(d Decoder, inputCanvasWidth, inputC
 			}
 		}
 		rect := image.Rect(0, 0, inputCanvasWidth, inputCanvasHeight)
-		return o.animatedCompositeBuffer.FillWithColor(d.BackgroundColor(), rect)
+		return o.animatedCompositeBuffer.ClearToTransparent(rect)
 	}
 
 	return nil
@@ -393,7 +393,7 @@ func (o *ImageOps) applyDisposeMethod(d Decoder) error {
 	switch active.dispose {
 	case DisposeToBackgroundColor:
 		rect := image.Rect(active.xOffset, active.yOffset, active.xOffset+active.Width(), active.yOffset+active.Height())
-		return o.animatedCompositeBuffer.FillWithColor(d.BackgroundColor(), rect)
+		return o.animatedCompositeBuffer.ClearToTransparent(rect)
 	case NoDispose:
 		// Do nothing
 	}


### PR DESCRIPTION
This PR addresses an issue with the handling of background colors in animated WebP processing. Previously, the background color specified in the WebP file was being applied as an opaque color, which could lead to unexpected results, particularly for WebPs with transparent backgrounds. The [WebP specification](https://developers.google.com/speed/webp/docs/riff_container#animation) states the background color may be considered optional during decoding, which this PR does.

### Key changes:
1. Replaced `FillWithColor` with `ClearToTransparent` in the initial setup of animated frame buffers.
2. Updated the `applyDisposeMethod` to use `ClearToTransparent` instead of `FillWithColor` when disposing to background color.
3. Modified the C++ code to implement a `clear_to_transparent` function, replacing the previous `set_color_rect` function.

These changes ensure that animated WebPs with transparent backgrounds are processed correctly, maintaining transparency in the output. This aligns our implementation more closely with the WebP specification and improves the handling of animated WebPs with varying levels of transparency.

### Testing:
- Verified correct behavior with various animated WebP inputs, including those with fully transparent and partially transparent backgrounds.
- Ensured no regression for non-animated or fully opaque WebP processing.