### PR TITLE
fix: Remove attempt to free animated WebP ICC color profile data.

### DIFF
--- a/webp_test.go
+++ b/webp_test.go
@@ -289,6 +289,15 @@ func testNewWebpEncoderWithAnimatedWebPSource(t *testing.T) {
 			resizeMethod:          ImageOpsFit,
 			disableAnimatedOutput: true,
 		},
+		{
+			name:         "Animated WebP - Crashing input",
+			inputPath:    "testdata/8202024-BGS-Headless-Horseman-OO-1200x1200-optimize.webp",
+			outputPath:   "testdata/out/8202024-BGS-Headless-Horseman-OO-1200x1200-optimize_out.webp",
+			width:        200,
+			height:       200,
+			quality:      60,
+			resizeMethod: ImageOpsFit,
+		},
 	}
 
 	for _, tc := range testCases {


### PR DESCRIPTION
Fixes a bug where a call was made to `WebPDataClear(&icc_data)` using externally owned ICC color profile data, potentially causing a panic. This call is unnecessary since the `icc_data` struct is block-scoped, and the ICC color profile data is associated with the encoder and is managed separately.