### PR TITLE
fix: Correct the dispose order for resize operation too.

### DIFF
--- a/ops.go
+++ b/ops.go
@@ -180,15 +180,15 @@ func (o *ImageOps) resize(d Decoder, inputCanvasWidth, inputCanvasHeight, output
 			return false, err
 		}
 
-		if err := o.applyDisposeMethod(d); err != nil {
-			return false, err
-		}
-
 		if err := o.applyBlendMethod(d); err != nil {
 			return false, err
 		}
 
 		if err := o.animatedCompositeBuffer.ResizeTo(outputCanvasWidth, outputCanvasHeight, o.secondary()); err != nil {
+			return false, err
+		}
+
+		if err := o.applyDisposeMethod(d); err != nil {
 			return false, err
 		}
 


### PR DESCRIPTION
Extension of https://github.com/discord/lilliput/pull/187 to also correct the dispose order for `resize` too.