### PR TITLE
fix: Move default color space assignment in avcodec.cpp

### DIFF
--- a/avcodec.cpp
+++ b/avcodec.cpp
@@ -413,7 +413,7 @@ static int avcodec_decoder_copy_frame(const avcodec_decoder d, opencv_mat mat, A
             NULL, NULL, NULL);
 
         // Configure colorspace
-        int colorspace = SWS_CS_ITU709;
+        int colorspace;
         switch (frame->colorspace) {
             case AVCOL_SPC_BT2020_NCL:
             case AVCOL_SPC_BT2020_CL:
@@ -427,6 +427,9 @@ static int avcodec_decoder_copy_frame(const avcodec_decoder d, opencv_mat mat, A
                 break;
             case AVCOL_SPC_SMPTE240M:
                 colorspace = SWS_CS_SMPTE240M;
+                break;
+            default:
+                colorspace = SWS_CS_ITU709;
                 break;
         }
         const int* inv_table = sws_getCoefficients(colorspace);


### PR DESCRIPTION
When compiling with newer versions of Go, a compiler warning was generated due to unhandled enumeration values in a switch statement within `avcodec.cpp`:
```
avcodec.cpp:417:17: warning: 11 enumeration values not handled in switch: 'AVCOL_SPC_RGB', 'AVCOL_SPC_BT709', 'AVCOL_SPC_UNSPECIFIED'... [-Wswitch]
```

## Solution
This pull request refactors the color space assignment logic in `avcodec.cpp`. Instead of initializing the `colorspace` variable to a default value before the switch statement, we now assign the default value in the `default` case of the switch. This change resolves the compiler warning and improves the clarity of our color space handling logic.

Note, this change does not alter the functional behavior of the color space conversion logic.
