### PR TITLE
fix: "smearing" of gifs with transparent pixels

### DIFF
--- a/giflib.cpp
+++ b/giflib.cpp
@@ -862,13 +862,6 @@ static bool giflib_encoder_render_frame(giflib_encoder e,
             int least_dist = INT_MAX;
             int best_color = 0;
             if (!(e->palette_lookup[crushed].present)) {
-                // calculate the best palette entry based on the midpoint of the crushed colors
-                // what this means is that we drop the crushed bits (& 0xf8)
-                // and then OR the highest-order crushed bit back in, which is approx midpoint
-                uint32_t R_center = (R & 0xf8) | 4;
-                uint32_t G_center = (G & 0xf8) | 4;
-                uint32_t B_center = (B & 0xf8) | 4;
-
                 // we're calculating the best, so keep track of which palette entry has least
                 // distance
                 int count = color_map->ColorCount;
@@ -877,9 +870,9 @@ static bool giflib_encoder_render_frame(giflib_encoder e,
                         // this index doesn't point to an actual color
                         continue;
                     }
-                    int dist = rgb_distance(R_center,
-                                            G_center,
-                                            B_center,
+                    int dist = rgb_distance(R,
+                                            G,
+                                            B,
                                             color_map->Colors[i].Red,
                                             color_map->Colors[i].Green,
                                             color_map->Colors[i].Blue);

--- a/giflib.cpp
+++ b/giflib.cpp
@@ -862,17 +862,28 @@ static bool giflib_encoder_render_frame(giflib_encoder e,
             int least_dist = INT_MAX;
             int best_color = 0;
             if (!(e->palette_lookup[crushed].present)) {
-                // we're calculating the best, so keep track of which palette entry has least
-                // distance
-                int count = color_map->ColorCount;
-                for (int i = 0; i < count; i++) {
-                    if (i == transparency_index) {
+
+                    bool is_extreme_color = (R > 240 && G > 240 && B > 240) || (R < 15 && G < 15 && B < 15);
+
+                    // calculate the best palette entry based on the midpoint of the crushed colors.
+                    // what this means is that we drop the crushed bits (& 0xf8)
+                    // and then OR the highest-order crushed bit back in, which is approx midpoint.
+                    // for extreme colors, use actual values
+                    uint32_t R_compare = is_extreme_color ? R : (R & 0xf8) | 4;
+                    uint32_t G_compare = is_extreme_color ? G : (G & 0xf8) | 4;
+                    uint32_t B_compare = is_extreme_color ? B : (B & 0xf8) | 4;
+
+                    // we're calculating the best, so keep track of which
+                    // palette entry has least distance
+                    int count = color_map->ColorCount;
+                    for (int i = 0; i < count; i++) {
+                      if (i == transparency_index) {
                         // this index doesn't point to an actual color
                         continue;
                     }
-                    int dist = rgb_distance(R,
-                                            G,
-                                            B,
+                    int dist = rgb_distance(R_compare,
+                                            G_compare,
+                                            B_compare,
                                             color_map->Colors[i].Red,
                                             color_map->Colors[i].Green,
                                             color_map->Colors[i].Blue);


### PR DESCRIPTION
Fixes: https://github.com/discord/lilliput/issues/84

## Problem

I tried this with a number of different gifs, seems like it only happened with these stark black/white ones. In the specific case from the linked issue, white pixels from the witch silhouette were being incorrectly marked as transparent when they should remain opaque. The transparency is causing the previous frame's content to show through, creating the smearing effect.
| in | out |
| - | - |
|![in](https://github.com/user-attachments/assets/d8ff4d9f-d219-42cd-b09a-bb673f2b7732)|![out](https://github.com/user-attachments/assets/7af8c08c-7a5a-46bf-87cd-7898ea30ed32)|



## Fix
So, we have a palette lookup table comprised of bit-crushed RGB values. For extreme colors like pure white (255,255,255), the crushed center calculation: `uint32_t R_center = (R & 0xf8) | 4;` meant taht for `R=255`, we'd get `252`, aka a slightly different color than what we actually had.

When comparing colors for transparency optimization, the `least_dist` we got from palette matching might have been larger than it should have been (because we used approximated colors), making it more likely for the transparency choice to "win" the comparison.

By using the actual RGB values instead, we get more accurate color matching against the palette, which means `least_dist` is more likely to be small for exact color matches. This makes it less likely for the transparency optimization to incorrectly override a good palette color match, especially for extreme colors like pure white or black.

