### PR TITLE
feat: Support compilation of native deps on OS X 15.

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -19,6 +19,7 @@ jobs:
       matrix:
         runs-on:
           - macos-14
+          - macos-15
           - ubuntu-22.04
       fail-fast: false
     runs-on: ${{ matrix.runs-on }}

--- a/.github/workflows/deps.yaml
+++ b/.github/workflows/deps.yaml
@@ -194,13 +194,13 @@ jobs:
       - name: Download macOS artifact
         uses: actions/download-artifact@v4
         with:
-          name: deps-macos-14.tar.gz
+          name: deps-macos-15.tar.gz
           path: .
 
       - name: Extract artifacts
         run: |
           tar xzf deps-linux.tar.gz
-          tar xzf deps-macos-14.tar.gz
+          tar xzf deps-macos-15.tar.gz
 
       - name: Verify artifacts match checked-in deps
         run: |

--- a/.github/workflows/deps.yaml
+++ b/.github/workflows/deps.yaml
@@ -67,9 +67,10 @@ jobs:
           name: deps-linux.tar.gz
           path: deps-linux.tar.gz
 
-  macos:
-    name: macOS
-    runs-on: macos-14
+  macos-14:
+    name: macOS 14
+    runs-on:
+      - macos-14
     steps:
       - name: Check out repo
         uses: actions/checkout@v4
@@ -112,13 +113,67 @@ jobs:
 
       - name: Create deps archive
         run: |
-          tar -czf deps-macos.tar.gz deps/osx/
+          tar -czf deps-macos-14.tar.gz deps/osx/
 
       - name: Upload deps artifact
         uses: actions/upload-artifact@v4
         with:
-          name: deps-macos.tar.gz
-          path: deps-macos.tar.gz
+          name: deps-macos-14.tar.gz
+          path: deps-macos-14.tar.gz
+
+  macos-15:
+    name: macOS 15
+    runs-on:
+      - macos-15
+    steps:
+      - name: Check out repo
+        uses: actions/checkout@v4
+
+      - name: Install build tools
+        run: |
+          brew install autoconf
+          brew install automake
+          brew install coreutils # for ffmpeg build
+          brew install libtool
+
+      - name: Build deps
+        run: |
+          echo "Starting dependency build..."
+          export MAKEFLAGS="-j$(nproc)"
+          ./deps/build-deps-osx.sh
+          echo "Dependency build completed"
+
+      - run: |
+          git status
+          git diff
+
+      - name: Install Go
+        uses: actions/setup-go@v5
+        with:
+          cache: false
+          go-version: "1.23"
+
+      - name: Build and test lilliput with the new deps
+        run: |
+          go build
+          go test -v
+
+      - name: Generate build info
+        run: |
+          ./deps/verify_deps.py generate \
+            --deps-dir deps/osx \
+            --platform macos \
+            --commit ${{ github.sha }}
+
+      - name: Create deps archive
+        run: |
+          tar -czf deps-macos-15.tar.gz deps/osx/
+
+      - name: Upload deps artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: deps-macos-15.tar.gz
+          path: deps-macos-15.tar.gz
 
   verify:
     name: Verify Build Artifacts
@@ -139,13 +194,13 @@ jobs:
       - name: Download macOS artifact
         uses: actions/download-artifact@v4
         with:
-          name: deps-macos.tar.gz
+          name: deps-macos-14.tar.gz
           path: .
 
       - name: Extract artifacts
         run: |
           tar xzf deps-linux.tar.gz
-          tar xzf deps-macos.tar.gz
+          tar xzf deps-macos-14.tar.gz
 
       - name: Verify artifacts match checked-in deps
         run: |
@@ -156,75 +211,3 @@ jobs:
           python3 ./deps/verify_deps.py verify \
             --deps-dir deps/osx \
             --build-info deps/osx/build-info.json
-
-  update-deps:
-    name: Update Checked-in Dependencies
-    needs: [linux, macos]
-    runs-on: ubuntu-latest
-    if: github.event_name == 'push' && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/master')
-    timeout-minutes: 15
-    
-    steps:
-      - name: Check out repo
-        uses: actions/checkout@v4
-
-      - name: Download Linux artifact
-        uses: actions/download-artifact@v4
-        with:
-          name: deps-linux.tar.gz
-          path: .
-
-      - name: Download macOS artifact
-        uses: actions/download-artifact@v4
-        with:
-          name: deps-macos.tar.gz
-          path: .
-
-      - name: Extract and update deps
-        run: |
-          # Remove existing deps directories to avoid stale files
-          rm -rf deps/linux/* deps/osx/*
-
-          tar xzf deps-linux.tar.gz
-          tar xzf deps-macos.tar.gz
-
-      - name: Commit updated deps
-        run: |
-          git config --local user.email "github-actions[bot]@users.noreply.github.com"
-          git config --local user.name "github-actions[bot]"
-          git config --local commit.gpgsign false
-          
-          # Stage each type of file explicitly
-          shopt -s nullglob # Handle case where globs don't match
-          
-          # Binary files
-          for f in deps/*/lib/*.{so,so.*,dylib,dylib.*,a}; do
-            if [ -f "$f" ]; then
-              git add -f "$f"
-            fi
-          done
-          
-          # Header files
-          for f in deps/*/include/**/*.h; do
-            if [ -f "$f" ]; then
-              git add -f "$f"
-            fi
-          done
-          
-          # Build info
-          for f in deps/*/build-info.json; do
-            if [ -f "$f" ]; then
-              git add -f "$f"
-            fi
-          done
-
-          # Only commit if there are changes
-          if ! git diff --cached --quiet; then
-            git commit -m "Update native dependencies from ${{ github.sha }} [skip ci]
-
-            Dependencies built by workflow run: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
-            
-            git push
-          else
-            echo "No changes to checked-in dependencies"
-          fi

--- a/deps/osx/share/OpenCV/OpenCVModules.cmake
+++ b/deps/osx/share/OpenCV/OpenCVModules.cmake
@@ -58,7 +58,7 @@ endif()
 add_library(opencv_core STATIC IMPORTED)
 
 set_target_properties(opencv_core PROPERTIES
-  INTERFACE_LINK_LIBRARIES "/Users/runner/work/lilliput/lilliput/deps/osx/lib/libz.a"
+  INTERFACE_LINK_LIBRARIES "${SRCDIR}/deps/osx/lib/libz.a"
 )
 
 # Create imported target opencv_imgproc


### PR DESCRIPTION
Support building the native codes dependencies on Mac OS X 15; previously this was limited to OS X 14. There were some minor changes required in the Lilliput build script for OS X. Also removes an unused CI stage meant to automatically check in compiled deps to the repo; this is not allowed for security reasons.

We'll continue to check in the dependencies compiled in Github CI for OS X 14. This change just ensures we can build for OS X 15 going forward, and makes an archive of OS X 15 compiled deps available for download through the Github CI build for anyone interested.