### PR TITLE
Feature: embed required deps via a embed file that is behind a unused build flag

### DIFF
--- a/embed.go
+++ b/embed.go
@@ -1,0 +1,11 @@
+//go:build EMBED_DEPS && darwin
+// +build EMBED_DEPS,darwin
+
+package lilliput
+
+import "embed"
+
+//go:embed deps/linux/*
+//go:embed deps/osx/*
+//go:embed icc_profiles/*
+var  embed.FS

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
 module github.com/discord/lilliput
 
-go 1.15
+go 1.16


### PR DESCRIPTION
Basically by creating an embed go file, go recognizes the dependencies and downloads them along with the lilliput library code.
By using a build flag, that isn't actually called at build time, the embed.go file is not added so nothing is actually being embedded into the binary. 

This downloads the deps for both linux and mac (tested on m1 and linux containers). I wonder if we could be fancy with the OS and download only the OS specific ones but this was sufficient for my use-case

closes #195 