### PR TITLE
misc: update build scripts to use release tag within lilliput-deps-source

### DIFF
--- a/deps/build-deps-linux.sh
+++ b/deps/build-deps-linux.sh
@@ -26,7 +26,7 @@ rm -rf aom
 rm -rf libavif
 
 if [ ! -d "$SRCDIR" ]; then
-    git clone https://github.com/discord/lilliput-dep-source "$SRCDIR"
+    git clone --depth 1 --branch 1.0.0 https://github.com/discord/lilliput-dep-source "$SRCDIR"
 fi
 
 echo '\n--------------------'

--- a/deps/build-deps-osx.sh
+++ b/deps/build-deps-osx.sh
@@ -52,7 +52,7 @@ rm -rf aom
 rm -rf libavif
 
 if [ ! -d "$SRCDIR" ]; then
-    git clone https://github.com/discord/lilliput-dep-source "$SRCDIR"
+    git clone --depth 1 --branch 1.0.0 https://github.com/discord/lilliput-dep-source "$SRCDIR"
 fi
 
 echo '\n--------------------'


### PR DESCRIPTION
## Summary
tag lilliput-deps-source with a new release, let's be a little bit safer around upgrades. using a shallow clone, since we dont need history of all deps, just the most recent one