### PR TITLE
feat. add clang format GH action and run clang-format

### DIFF
--- a/.github/workflows/clang-format-check.yml
+++ b/.github/workflows/clang-format-check.yml
@@ -1,0 +1,24 @@
+name: clang-format Check
+
+on:
+  pull_request:
+    paths:
+      - '*.cpp'
+      - '*.hpp'
+  push:
+    paths:
+      - '*.cpp'
+      - '*.hpp'
+
+jobs:
+  format:
+    runs-on: ubuntu-latest
+    name: Formatting Check
+    steps:
+      - uses: actions/checkout@v4
+      - name: Run clang-format on root cpp/hpp files
+        uses: jidicula/clang-format-action@v4.15.0
+        with:
+          clang-format-version: '20'
+          check-path: '.'
+          include-regex: '^[^/]+\.(cpp|hpp)$'

--- a/.github/workflows/clang-format-check.yml
+++ b/.github/workflows/clang-format-check.yml
@@ -12,7 +12,7 @@ on:
 
 jobs:
   format:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     name: Formatting Check
     steps:
       - uses: actions/checkout@v4

--- a/avif.cpp
+++ b/avif.cpp
@@ -37,19 +37,22 @@ struct avif_encoder_struct {
 // HDR Support Functions
 //----------------------
 // Check if source is HDR based on bit depth, primaries and transfer characteristics
-static bool avif_is_hdr_source(const avifImage* image) {
-    if (!image) return false;
-    
+static bool avif_is_hdr_source(const avifImage* image)
+{
+    if (!image)
+        return false;
+
     bool high_bit_depth = image->depth > 8;
     bool hdr_primaries = image->colorPrimaries == AVIF_COLOR_PRIMARIES_BT2020;
     bool hdr_transfer = (image->transferCharacteristics == AVIF_TRANSFER_CHARACTERISTICS_PQ) ||
-                       (image->transferCharacteristics == AVIF_TRANSFER_CHARACTERISTICS_HLG);
-    
+      (image->transferCharacteristics == AVIF_TRANSFER_CHARACTERISTICS_HLG);
+
     return high_bit_depth && (hdr_primaries || hdr_transfer);
 }
 
 // Convert PQ (SMPTE ST.2084) to linear
-static float avif_pq_to_linear(float x) {
+static float avif_pq_to_linear(float x)
+{
     const float m1 = 0.1593017578125;
     const float m2 = 78.84375;
     const float c1 = 0.8359375;
@@ -60,32 +63,40 @@ static float avif_pq_to_linear(float x) {
     float num = std::max(xpow - c1, 0.0f);
     float den = c2 - c3 * xpow;
     float linear = std::pow(num / den, 1.0f / m1);
-    
+
     return linear;
 }
 
 // Convert HLG to linear
-static float avif_hlg_to_linear(float x) {
+static float avif_hlg_to_linear(float x)
+{
     const float a = 0.17883277;
     const float b = 0.28466892;
     const float c = 0.55991073;
-    
+
     if (x <= 0.5f) {
         return x * x / 3.0f;
-    } else {
+    }
+    else {
         return (std::exp((x - c) / a) + b) / 12.0f;
     }
 }
 
 // Convert HDR RGB values to SDR using OpenCV's tone-mapping
-static void avif_tonemap_rgb(uint16_t* src, uint8_t* dst, int width, int height, int src_depth, 
-                            avifTransferCharacteristics transfer, avifColorPrimaries primaries) {
+static void avif_tonemap_rgb(uint16_t* src,
+                             uint8_t* dst,
+                             int width,
+                             int height,
+                             int src_depth,
+                             avifTransferCharacteristics transfer,
+                             avifColorPrimaries primaries)
+{
     float scale = 1.0f / ((1 << src_depth) - 1);
-    
+
     // Create OpenCV matrices for processing
     cv::Mat hdrMat(height, width, CV_32FC3);
     cv::Mat sdrMat(height, width, CV_8UC3);
-    
+
     // Convert to linear RGB
     for (int y = 0; y < height; y++) {
         for (int x = 0; x < width; x++) {
@@ -93,18 +104,19 @@ static void avif_tonemap_rgb(uint16_t* src, uint8_t* dst, int width, int height,
             float r = src[idx] * scale;
             float g = src[idx + 1] * scale;
             float b = src[idx + 2] * scale;
-            
+
             // Convert to linear
             if (transfer == AVIF_TRANSFER_CHARACTERISTICS_PQ) {
                 r = avif_pq_to_linear(r);
                 g = avif_pq_to_linear(g);
                 b = avif_pq_to_linear(b);
-            } else if (transfer == AVIF_TRANSFER_CHARACTERISTICS_HLG) {
+            }
+            else if (transfer == AVIF_TRANSFER_CHARACTERISTICS_HLG) {
                 r = avif_hlg_to_linear(r);
                 g = avif_hlg_to_linear(g);
                 b = avif_hlg_to_linear(b);
             }
-            
+
             hdrMat.at<cv::Vec3f>(y, x) = cv::Vec3f(r, g, b);
         }
     }
@@ -118,26 +130,21 @@ static void avif_tonemap_rgb(uint16_t* src, uint8_t* dst, int width, int height,
     cv::Mat converted;
     if (primaries == AVIF_COLOR_PRIMARIES_BT2020) {
         cv::Matx33f bt2020_to_bt709(
-            1.6605f, -0.5876f, -0.0728f,
-            -0.1246f, 1.1329f, -0.0083f,
-            -0.0182f, -0.1006f, 1.1187f
-        );
+          1.6605f, -0.5876f, -0.0728f, -0.1246f, 1.1329f, -0.0083f, -0.0182f, -0.1006f, 1.1187f);
         cv::transform(tonemapped, converted, bt2020_to_bt709);
-    } else if (primaries == AVIF_COLOR_PRIMARIES_SMPTE432 || primaries == AVIF_COLOR_PRIMARIES_DCI_P3) {
+    }
+    else if (primaries == AVIF_COLOR_PRIMARIES_SMPTE432 ||
+             primaries == AVIF_COLOR_PRIMARIES_DCI_P3) {
         cv::Matx33f p3_to_bt709(
-            1.2249f, -0.2247f, -0.0002f,
-            -0.0420f, 1.0419f, 0.0001f,
-            -0.0197f, 0.0754f, 0.9443f
-        );
+          1.2249f, -0.2247f, -0.0002f, -0.0420f, 1.0419f, 0.0001f, -0.0197f, 0.0754f, 0.9443f);
         cv::transform(tonemapped, converted, p3_to_bt709);
-    } else if (primaries == AVIF_COLOR_PRIMARIES_BT601) {
+    }
+    else if (primaries == AVIF_COLOR_PRIMARIES_BT601) {
         cv::Matx33f bt601_to_bt709(
-            1.0440f, -0.0440f, 0.0000f,
-            -0.0000f, 1.0000f, 0.0000f,
-            0.0000f, 0.0000f, 1.0000f
-        );
+          1.0440f, -0.0440f, 0.0000f, -0.0000f, 1.0000f, 0.0000f, 0.0000f, 0.0000f, 1.0000f);
         cv::transform(tonemapped, converted, bt601_to_bt709);
-    } else {
+    }
+    else {
         // For unknown colorspaces, default to assuming BT709
         converted = tonemapped;
     }
@@ -145,8 +152,9 @@ static void avif_tonemap_rgb(uint16_t* src, uint8_t* dst, int width, int height,
     // Convert to 8-bit with proper gamma correction
     cv::Mat gamma_corrected;
     if (transfer == AVIF_TRANSFER_CHARACTERISTICS_LINEAR) {
-        cv::pow(converted, 1.0f/2.2f, gamma_corrected);
-    } else {
+        cv::pow(converted, 1.0f / 2.2f, gamma_corrected);
+    }
+    else {
         // PQ and HLG already include transfer function
         gamma_corrected = converted;
     }
@@ -156,42 +164,48 @@ static void avif_tonemap_rgb(uint16_t* src, uint8_t* dst, int width, int height,
 }
 
 // Convert YUV to RGB with optional HDR tone-mapping
-static avifResult avif_convert_yuv_to_rgb_with_tone_mapping(avifImage* image, avifRGBImage* rgb, bool enable_tone_mapping) {
+static avifResult avif_convert_yuv_to_rgb_with_tone_mapping(avifImage* image,
+                                                            avifRGBImage* rgb,
+                                                            bool enable_tone_mapping)
+{
     if (!enable_tone_mapping || !avif_is_hdr_source(image)) {
         // Not HDR or tone-mapping disabled, proceed with normal YUV to RGB conversion
         return avifImageYUVToRGB(image, rgb);
     }
-    
+
     // For HDR with tone-mapping enabled, we need to:
     // 1. Convert YUV to high bit depth RGB
     // 2. Apply tone-mapping
     // 3. Convert to 8-bit RGB
-    
+
     // First convert YUV to high bit depth RGB
     avifRGBImage temp;
     avifRGBImageSetDefaults(&temp, image);
     temp.depth = image->depth;
     temp.format = rgb->format;
-    
+
     avifResult result = avifRGBImageAllocatePixels(&temp);
     if (result != AVIF_RESULT_OK) {
         fprintf(stderr, "Failed to allocate pixels for temp image\n");
         return result;
     }
-    
+
     result = avifImageYUVToRGB(image, &temp);
     if (result != AVIF_RESULT_OK) {
         fprintf(stderr, "Failed to convert YUV to RGB\n");
         avifRGBImageFreePixels(&temp);
         return result;
     }
-    
+
     // Apply tone-mapping with colorspace information
-    avif_tonemap_rgb((uint16_t*)temp.pixels, rgb->pixels, 
-                     image->width, image->height, 
-                     temp.depth, image->transferCharacteristics,
+    avif_tonemap_rgb((uint16_t*)temp.pixels,
+                     rgb->pixels,
+                     image->width,
+                     image->height,
+                     temp.depth,
+                     image->transferCharacteristics,
                      image->colorPrimaries);
-    
+
     avifRGBImageFreePixels(&temp);
     return AVIF_RESULT_OK;
 }
@@ -199,7 +213,8 @@ static avifResult avif_convert_yuv_to_rgb_with_tone_mapping(avifImage* image, av
 //----------------------
 // Decoder Management
 //----------------------
-avif_decoder avif_decoder_create(const opencv_mat buf, const bool tone_mapping_enabled) {
+avif_decoder avif_decoder_create(const opencv_mat buf, const bool tone_mapping_enabled)
+{
     auto cvMat = static_cast<const cv::Mat*>(buf);
     if (!cvMat || cvMat->empty()) {
         return nullptr;
@@ -212,7 +227,7 @@ avif_decoder avif_decoder_create(const opencv_mat buf, const bool tone_mapping_e
     d->buffer_size = cvMat->total();
     d->decoder = avifDecoderCreate();
     d->tone_mapping_enabled = tone_mapping_enabled;
-    
+
     if (!d->decoder) {
         delete d;
         return nullptr;
@@ -237,8 +252,9 @@ avif_decoder avif_decoder_create(const opencv_mat buf, const bool tone_mapping_e
     }
 
     d->frame_count = d->decoder->imageCount;
-    d->total_duration = (d->frame_count > 1) ? 
-        (int)((double)d->decoder->durationInTimescales * 1000.0 / d->decoder->timescale) : 0;
+    d->total_duration = (d->frame_count > 1)
+      ? (int)((double)d->decoder->durationInTimescales * 1000.0 / d->decoder->timescale)
+      : 0;
 
     // Read the first frame
     result = avifDecoderNextImage(d->decoder);
@@ -252,7 +268,7 @@ avif_decoder avif_decoder_create(const opencv_mat buf, const bool tone_mapping_e
     avifRGBImageSetDefaults(&d->rgb, d->decoder->image);
     d->rgb.format = AVIF_RGB_FORMAT_BGR;
     d->rgb.depth = 8;
-    
+
     d->has_alpha = d->decoder->image->alphaPlane != nullptr;
     if (d->has_alpha) {
         d->rgb.format = AVIF_RGB_FORMAT_BGRA;
@@ -272,7 +288,8 @@ avif_decoder avif_decoder_create(const opencv_mat buf, const bool tone_mapping_e
     return d;
 }
 
-void avif_decoder_release(avif_decoder d) {
+void avif_decoder_release(avif_decoder d)
+{
     if (d) {
         if (d->decoder) {
             avifRGBImageFreePixels(&d->rgb);
@@ -285,49 +302,56 @@ void avif_decoder_release(avif_decoder d) {
 //----------------------
 // Decoder Properties
 //----------------------
-int avif_decoder_get_width(const avif_decoder d) {
+int avif_decoder_get_width(const avif_decoder d)
+{
     if (!d || !d->decoder) {
         return 0;
     }
     return d->decoder->image->width;
 }
 
-int avif_decoder_get_height(const avif_decoder d) {
+int avif_decoder_get_height(const avif_decoder d)
+{
     if (!d || !d->decoder) {
         return 0;
     }
     return d->decoder->image->height;
 }
 
-int avif_decoder_get_pixel_type(const avif_decoder d) {
+int avif_decoder_get_pixel_type(const avif_decoder d)
+{
     if (!d || !d->decoder) {
         return 0;
     }
     return d->has_alpha ? CV_8UC4 : CV_8UC3;
 }
 
-bool avif_decoder_is_animated(const avif_decoder d) {
+bool avif_decoder_is_animated(const avif_decoder d)
+{
     if (!d || !d->decoder) {
         return false;
     }
     return d->frame_count > 1;
 }
 
-int avif_decoder_get_frame_count(const avif_decoder d) {
+int avif_decoder_get_frame_count(const avif_decoder d)
+{
     if (!d || !d->decoder) {
         return 0;
     }
     return d->frame_count;
 }
 
-int avif_decoder_get_num_frames(const avif_decoder d) {
+int avif_decoder_get_num_frames(const avif_decoder d)
+{
     if (!d || !d->decoder) {
         return 0;
     }
     return d->frame_count;
 }
 
-uint32_t avif_decoder_get_duration(const avif_decoder d) {
+uint32_t avif_decoder_get_duration(const avif_decoder d)
+{
     if (!d || !d->decoder) {
         return 0;
     }
@@ -335,20 +359,22 @@ uint32_t avif_decoder_get_duration(const avif_decoder d) {
     return (uint32_t)(d->decoder->duration * 1000.0f);
 }
 
-uint32_t avif_decoder_get_loop_count(const avif_decoder d) {
+uint32_t avif_decoder_get_loop_count(const avif_decoder d)
+{
     if (!d || !d->decoder) {
         return 0;
     }
     switch (d->decoder->repetitionCount) {
-        case AVIF_REPETITION_COUNT_INFINITE:
-        case AVIF_REPETITION_COUNT_UNKNOWN:
-            return 0;
-        default:
-            return d->decoder->repetitionCount;
+    case AVIF_REPETITION_COUNT_INFINITE:
+    case AVIF_REPETITION_COUNT_UNKNOWN:
+        return 0;
+    default:
+        return d->decoder->repetitionCount;
     }
 }
 
-size_t avif_decoder_get_icc(const avif_decoder d, void* buf, size_t buf_len) {
+size_t avif_decoder_get_icc(const avif_decoder d, void* buf, size_t buf_len)
+{
     if (!d || !d->decoder) {
         return 0;
     }
@@ -370,14 +396,16 @@ size_t avif_decoder_get_icc(const avif_decoder d, void* buf, size_t buf_len) {
     return 0;
 }
 
-uint32_t avif_decoder_get_bg_color(const avif_decoder d) {
+uint32_t avif_decoder_get_bg_color(const avif_decoder d)
+{
     if (!d || !d->decoder) {
         return DEFAULT_BACKGROUND_COLOR;
     }
     return d->bgcolor;
 }
 
-int avif_decoder_get_total_duration(const avif_decoder d) {
+int avif_decoder_get_total_duration(const avif_decoder d)
+{
     if (!d || !d->decoder) {
         return 0;
     }
@@ -387,7 +415,8 @@ int avif_decoder_get_total_duration(const avif_decoder d) {
 //----------------------
 // Frame Properties
 //----------------------
-int avif_decoder_get_frame_duration(const avif_decoder d) {
+int avif_decoder_get_frame_duration(const avif_decoder d)
+{
     if (!d || !d->decoder) {
         return 0;
     }
@@ -395,21 +424,24 @@ int avif_decoder_get_frame_duration(const avif_decoder d) {
     return (int)(d->decoder->imageTiming.duration * 1000.0f);
 }
 
-int avif_decoder_get_frame_dispose(const avif_decoder d) {
+int avif_decoder_get_frame_dispose(const avif_decoder d)
+{
     if (!d || !d->decoder || !d->decoder->image) {
         return 0;
     }
     return d->decoder->image->imageOwnsYUVPlanes ? AVIF_DISPOSE_BACKGROUND : AVIF_DISPOSE_NONE;
 }
 
-int avif_decoder_get_frame_blend(const avif_decoder d) {
+int avif_decoder_get_frame_blend(const avif_decoder d)
+{
     if (!d || !d->decoder || !d->decoder->image) {
         return AVIF_BLEND_NONE;
     }
     return d->has_alpha ? AVIF_BLEND_ALPHA : AVIF_BLEND_NONE;
 }
 
-int avif_decoder_get_frame_x_offset(const avif_decoder d) {
+int avif_decoder_get_frame_x_offset(const avif_decoder d)
+{
     if (!d || !d->decoder || !d->decoder->image) {
         return 0;
     }
@@ -420,7 +452,8 @@ int avif_decoder_get_frame_x_offset(const avif_decoder d) {
     return 0;
 }
 
-int avif_decoder_get_frame_y_offset(const avif_decoder d) {
+int avif_decoder_get_frame_y_offset(const avif_decoder d)
+{
     if (!d || !d->decoder || !d->decoder->image) {
         return 0;
     }
@@ -434,7 +467,8 @@ int avif_decoder_get_frame_y_offset(const avif_decoder d) {
 //----------------------
 // Frame Operations
 //----------------------
-bool avif_decoder_decode(avif_decoder d, opencv_mat mat) {
+bool avif_decoder_decode(avif_decoder d, opencv_mat mat)
+{
     if (!d || !d->decoder) {
         fprintf(stderr, "Decoder null check failed\n");
         return false;
@@ -447,24 +481,30 @@ bool avif_decoder_decode(avif_decoder d, opencv_mat mat) {
     }
 
     // Convert YUV to RGB with optional HDR handling
-    avifResult result = avif_convert_yuv_to_rgb_with_tone_mapping(d->decoder->image, &d->rgb, d->tone_mapping_enabled);
+    avifResult result = avif_convert_yuv_to_rgb_with_tone_mapping(
+      d->decoder->image, &d->rgb, d->tone_mapping_enabled);
     if (result != AVIF_RESULT_OK) {
-        fprintf(stderr, "YUV to RGB conversion failed for frame %d: %s\n", d->current_frame, avifResultToString(result));
+        fprintf(stderr,
+                "YUV to RGB conversion failed for frame %d: %s\n",
+                d->current_frame,
+                avifResultToString(result));
         return false;
     }
 
     // Create OpenCV matrix from AVIF buffer
     auto cvMat = static_cast<cv::Mat*>(mat);
-    cv::Mat srcMat(d->rgb.height, d->rgb.width, 
-                   d->has_alpha ? CV_8UC4 : CV_8UC3, 
-                   d->rgb.pixels, 
+    cv::Mat srcMat(d->rgb.height,
+                   d->rgb.width,
+                   d->has_alpha ? CV_8UC4 : CV_8UC3,
+                   d->rgb.pixels,
                    d->rgb.rowBytes);
-    
+
     // Keep BGR/BGRA format
     if (d->has_alpha) {
         // Direct copy since it's already in BGRA format
         srcMat.copyTo(*cvMat);
-    } else {
+    }
+    else {
         // For non-alpha images, just add alpha channel to BGR
         cv::Mat alpha(srcMat.rows, srcMat.cols, CV_8UC1, cv::Scalar(255));
         std::vector<cv::Mat> channels;
@@ -477,23 +517,25 @@ bool avif_decoder_decode(avif_decoder d, opencv_mat mat) {
     if (d->current_frame < d->frame_count - 1) {
         // Free current RGB pixels before moving to next frame
         avifRGBImageFreePixels(&d->rgb);
-        
+
         result = avifDecoderNextImage(d->decoder);
         if (result != AVIF_RESULT_OK) {
             fprintf(stderr, "Failed to advance to next frame: %s\n", avifResultToString(result));
             return false;
         }
-        
+
         // Reinitialize RGB image for the new frame
         avifRGBImageSetDefaults(&d->rgb, d->decoder->image);
         d->rgb.format = d->has_alpha ? AVIF_RGB_FORMAT_BGRA : AVIF_RGB_FORMAT_BGR;
         d->rgb.depth = 8;
-        
+
         // Reallocate pixels for the new frame
         result = avifRGBImageAllocatePixels(&d->rgb);
         if (result != AVIF_RESULT_OK) {
-            fprintf(stderr, "Failed to allocate RGB pixels for frame %d: %s\n", 
-                   d->current_frame, avifResultToString(result));
+            fprintf(stderr,
+                    "Failed to allocate RGB pixels for frame %d: %s\n",
+                    d->current_frame,
+                    avifResultToString(result));
             return false;
         }
     }
@@ -501,7 +543,8 @@ bool avif_decoder_decode(avif_decoder d, opencv_mat mat) {
     return true;
 }
 
-int avif_decoder_has_more_frames(avif_decoder d) {
+int avif_decoder_has_more_frames(avif_decoder d)
+{
     if (!d || !d->decoder) {
         return 0;
     }
@@ -511,7 +554,12 @@ int avif_decoder_has_more_frames(avif_decoder d) {
 //----------------------
 // Encoder Management
 //----------------------
-avif_encoder avif_encoder_create(void* buf, size_t buf_len, const void* icc, size_t icc_len, int loop_count) {
+avif_encoder avif_encoder_create(void* buf,
+                                 size_t buf_len,
+                                 const void* icc,
+                                 size_t icc_len,
+                                 int loop_count)
+{
     auto e = new avif_encoder_struct();
     memset(e, 0, sizeof(avif_encoder_struct));
 
@@ -523,17 +571,17 @@ avif_encoder avif_encoder_create(void* buf, size_t buf_len, const void* icc, siz
 
     e->dst = static_cast<uint8_t*>(buf);
     e->dst_len = buf_len;
-    
+
     if (icc && icc_len > 0) {
         e->icc = static_cast<const uint8_t*>(icc);
         e->icc_len = icc_len;
     }
 
     // Configure encoder for animation support
-    e->encoder->maxThreads = 1;  // Ensure thread-safe encoding
+    e->encoder->maxThreads = 1; // Ensure thread-safe encoding
     e->encoder->repetitionCount = loop_count == 0 ? AVIF_REPETITION_COUNT_INFINITE : loop_count;
-    e->encoder->quality = 60;    // Default quality
-    e->encoder->timescale = 1000;  // Use milliseconds as timescale (1000 ticks per second)
+    e->encoder->quality = 60;     // Default quality
+    e->encoder->timescale = 1000; // Use milliseconds as timescale (1000 ticks per second)
     e->encoder->speed = AVIF_SPEED_DEFAULT;
     e->encoder->keyframeInterval = 0; // Let encoder decide keyframes
     e->encoder->minQuantizer = AVIF_QUANTIZER_BEST_QUALITY;
@@ -542,7 +590,8 @@ avif_encoder avif_encoder_create(void* buf, size_t buf_len, const void* icc, siz
     return e;
 }
 
-void avif_encoder_release(avif_encoder e) {
+void avif_encoder_release(avif_encoder e)
+{
     if (e) {
         if (e->encoder) {
             avifEncoderDestroy(e->encoder);
@@ -554,7 +603,14 @@ void avif_encoder_release(avif_encoder e) {
 //----------------------
 // Encoder Operations
 //----------------------
-size_t avif_encoder_write(avif_encoder e, const opencv_mat src, const int* opt, size_t opt_len, int delay_ms, int blend, int dispose) {
+size_t avif_encoder_write(avif_encoder e,
+                          const opencv_mat src,
+                          const int* opt,
+                          size_t opt_len,
+                          int delay_ms,
+                          int blend,
+                          int dispose)
+{
     if (!e || !e->encoder) {
         fprintf(stderr, "AVIF Encoder: null check failed\n");
         return 0;
@@ -564,9 +620,10 @@ size_t avif_encoder_write(avif_encoder e, const opencv_mat src, const int* opt, 
     if (!src) {
         avifRWData output = AVIF_DATA_EMPTY;
         avifResult result = avifEncoderFinish(e->encoder, &output);
-        
+
         if (result != AVIF_RESULT_OK || output.size == 0) {
-            fprintf(stderr, "AVIF Encoder: flush failed with error: %s\n", avifResultToString(result));
+            fprintf(
+              stderr, "AVIF Encoder: flush failed with error: %s\n", avifResultToString(result));
             avifRWDataFree(&output);
             return 0;
         }
@@ -599,7 +656,8 @@ size_t avif_encoder_write(avif_encoder e, const opencv_mat src, const int* opt, 
     if (e->icc && e->icc_len > 0 && e->frame_count == 0) {
         avifResult result = avifImageSetProfileICC(avifImage, e->icc, e->icc_len);
         if (result != AVIF_RESULT_OK) {
-            fprintf(stderr, "AVIF Encoder: failed to set ICC profile: %s\n", avifResultToString(result));
+            fprintf(
+              stderr, "AVIF Encoder: failed to set ICC profile: %s\n", avifResultToString(result));
             return 0;
         }
     }
@@ -608,7 +666,8 @@ size_t avif_encoder_write(avif_encoder e, const opencv_mat src, const int* opt, 
     for (size_t i = 0; i + 1 < opt_len; i += 2) {
         if (opt[i] == AVIF_QUALITY) {
             e->encoder->quality = std::min(100, std::max(0, opt[i + 1]));
-        } else if (opt[i] == AVIF_SPEED) {
+        }
+        else if (opt[i] == AVIF_SPEED) {
             e->encoder->speed = std::min(10, std::max(0, opt[i + 1]));
         }
     }
@@ -616,7 +675,7 @@ size_t avif_encoder_write(avif_encoder e, const opencv_mat src, const int* opt, 
     // Convert from BGR/BGRA to YUV
     avifRGBImage rgb;
     avifRGBImageSetDefaults(&rgb, avifImage);
-    
+
     // Set the correct pixel format based on input channels
     rgb.format = cvMat->channels() == 4 ? AVIF_RGB_FORMAT_BGRA : AVIF_RGB_FORMAT_BGR;
     rgb.depth = 8;
@@ -627,7 +686,8 @@ size_t avif_encoder_write(avif_encoder e, const opencv_mat src, const int* opt, 
 
     avifResult result = avifImageRGBToYUV(avifImage, &rgb);
     if (result != AVIF_RESULT_OK) {
-        fprintf(stderr, "AVIF Encoder: RGB to YUV conversion failed: %s\n", avifResultToString(result));
+        fprintf(
+          stderr, "AVIF Encoder: RGB to YUV conversion failed: %s\n", avifResultToString(result));
         avifImageDestroy(avifImage);
         return 0;
     }
@@ -635,7 +695,7 @@ size_t avif_encoder_write(avif_encoder e, const opencv_mat src, const int* opt, 
     // Set up frame timing and flags
     float durationInTimescale = (float)delay_ms * e->encoder->timescale;
     if (durationInTimescale < e->encoder->timescale) {
-        durationInTimescale = e->encoder->timescale;  // Ensure minimum duration
+        durationInTimescale = e->encoder->timescale; // Ensure minimum duration
     }
     float durationInSeconds = durationInTimescale / e->encoder->timescale;
 
@@ -658,6 +718,7 @@ size_t avif_encoder_write(avif_encoder e, const opencv_mat src, const int* opt, 
     return 1; // Return success without actual data (data comes in flush)
 }
 
-size_t avif_encoder_flush(avif_encoder e) {
+size_t avif_encoder_flush(avif_encoder e)
+{
     return avif_encoder_write(e, nullptr, nullptr, 0, 0, 0, 0);
 }

--- a/avif.hpp
+++ b/avif.hpp
@@ -10,20 +10,11 @@ extern "C" {
 //----------------------
 // Enums & Constants
 //----------------------
-enum AvifBlendMode {
-    AVIF_BLEND_ALPHA = 0,
-    AVIF_BLEND_NONE = 1
-};
+enum AvifBlendMode { AVIF_BLEND_ALPHA = 0, AVIF_BLEND_NONE = 1 };
 
-enum AvifDisposeMode {
-    AVIF_DISPOSE_NONE = 0,
-    AVIF_DISPOSE_BACKGROUND = 1
-};
+enum AvifDisposeMode { AVIF_DISPOSE_NONE = 0, AVIF_DISPOSE_BACKGROUND = 1 };
 
-enum AvifEncoderOptions {
-    AVIF_QUALITY = 1,
-    AVIF_SPEED = 2
-};
+enum AvifEncoderOptions { AVIF_QUALITY = 1, AVIF_SPEED = 2 };
 
 //----------------------
 // Type Definitions
@@ -68,17 +59,27 @@ int avif_decoder_has_more_frames(avif_decoder d);
 //----------------------
 // Encoder Management
 //----------------------
-avif_encoder avif_encoder_create(void* buf, size_t buf_len, const void* icc, size_t icc_len, int loop_count);
+avif_encoder avif_encoder_create(void* buf,
+                                 size_t buf_len,
+                                 const void* icc,
+                                 size_t icc_len,
+                                 int loop_count);
 void avif_encoder_release(avif_encoder e);
 
 //----------------------
 // Encoder Operations
 //----------------------
-size_t avif_encoder_write(avif_encoder e, const opencv_mat src, const int* opt, size_t opt_len, int delay_ms, int blend, int dispose);
+size_t avif_encoder_write(avif_encoder e,
+                          const opencv_mat src,
+                          const int* opt,
+                          size_t opt_len,
+                          int delay_ms,
+                          int blend,
+                          int dispose);
 size_t avif_encoder_flush(avif_encoder e);
 
 #ifdef __cplusplus
 }
 #endif
 
-#endif 
+#endif

--- a/opencv.cpp
+++ b/opencv.cpp
@@ -217,13 +217,15 @@ struct opencv_jpeg_error_mgr {
     jmp_buf setjmp_buffer;
 };
 
-void opencv_jpeg_error_exit(j_common_ptr cinfo) {
-    opencv_jpeg_error_mgr* myerr = (opencv_jpeg_error_mgr*) cinfo->err;
+void opencv_jpeg_error_exit(j_common_ptr cinfo)
+{
+    opencv_jpeg_error_mgr* myerr = (opencv_jpeg_error_mgr*)cinfo->err;
     (*cinfo->err->output_message)(cinfo);
     longjmp(myerr->setjmp_buffer, 1);
 }
 
-int opencv_decoder_get_jpeg_icc(void* src, size_t src_len, void* dest, size_t dest_len) {
+int opencv_decoder_get_jpeg_icc(void* src, size_t src_len, void* dest, size_t dest_len)
+{
     struct jpeg_decompress_struct cinfo;
     struct opencv_jpeg_error_mgr jerr;
 
@@ -249,7 +251,7 @@ int opencv_decoder_get_jpeg_icc(void* src, size_t src_len, void* dest, size_t de
     }
 
     // Check if ICC profile is available
-    JOCTET *icc_profile = nullptr;
+    JOCTET* icc_profile = nullptr;
     unsigned int icc_length = 0;
     if (jpeg_read_icc_profile(&cinfo, &icc_profile, &icc_length)) {
         if (icc_length > 0 && icc_length <= dest_len) {
@@ -268,10 +270,11 @@ int opencv_decoder_get_jpeg_icc(void* src, size_t src_len, void* dest, size_t de
     return 0;
 }
 
-void opencv_decoder_png_read(png_structp png_ptr, png_bytep data, png_size_t length) {
+void opencv_decoder_png_read(png_structp png_ptr, png_bytep data, png_size_t length)
+{
     auto buffer_info = reinterpret_cast<std::pair<const char**, size_t*>*>(png_get_io_ptr(png_ptr));
-    const char* &buffer = *buffer_info->first;
-    size_t &buffer_size = *buffer_info->second;
+    const char*& buffer = *buffer_info->first;
+    size_t& buffer_size = *buffer_info->second;
 
     if (buffer_size < length) {
         png_error(png_ptr, "Read error: attempting to read beyond buffer size");
@@ -283,7 +286,8 @@ void opencv_decoder_png_read(png_structp png_ptr, png_bytep data, png_size_t len
     buffer_size -= length;
 }
 
-int opencv_decoder_get_png_icc(void* src, size_t src_len, void* dest, size_t dest_len) {
+int opencv_decoder_get_png_icc(void* src, size_t src_len, void* dest, size_t dest_len)
+{
     // Set up libpng to read from memory
     const char* buffer = reinterpret_cast<const char*>(src);
     size_t buffer_size = src_len;
@@ -317,10 +321,11 @@ int opencv_decoder_get_png_icc(void* src, size_t src_len, void* dest, size_t des
 
 /**
  * @brief Reset all pixels in the matrix to zero.
- * 
+ *
  * @param mat Pointer to the OpenCV matrix to be reset.
  */
-void opencv_mat_reset(opencv_mat mat) {
+void opencv_mat_reset(opencv_mat mat)
+{
     if (mat) {
         cv::Mat* m = static_cast<cv::Mat*>(mat);
         m->setTo(cv::Scalar(0));
@@ -329,24 +334,26 @@ void opencv_mat_reset(opencv_mat mat) {
 
 /**
  * @brief Set the entire matrix to a specific color.
- * 
+ *
  * @param mat Pointer to the OpenCV matrix to be colored.
  * @param red Red component of the color (0-255).
  * @param green Green component of the color (0-255).
  * @param blue Blue component of the color (0-255).
  * @param alpha Alpha component of the color (0-255). If negative, treated as a 3-channel image.
  */
-void opencv_mat_set_color(opencv_mat mat, int red, int green, int blue, int alpha) {
+void opencv_mat_set_color(opencv_mat mat, int red, int green, int blue, int alpha)
+{
     auto cvMat = static_cast<cv::Mat*>(mat);
     if (cvMat) {
-        cv::Scalar color = (alpha >= 0) ? cv::Scalar(blue, green, red, alpha) : cv::Scalar(blue, green, red);
+        cv::Scalar color =
+          (alpha >= 0) ? cv::Scalar(blue, green, red, alpha) : cv::Scalar(blue, green, red);
         cvMat->setTo(color);
     }
 }
 
 /**
  * @brief Clear a rectangular region of the matrix to transparent.
- * 
+ *
  * @param mat Pointer to the OpenCV matrix to be modified.
  * @param xOffset X-coordinate of the top-left corner of the rectangle.
  * @param yOffset Y-coordinate of the top-left corner of the rectangle.
@@ -354,13 +361,15 @@ void opencv_mat_set_color(opencv_mat mat, int red, int green, int blue, int alph
  * @param height Height of the rectangle.
  * @return int Error code.
  */
-int opencv_mat_clear_to_transparent(opencv_mat mat, int xOffset, int yOffset, int width, int height) {
+int opencv_mat_clear_to_transparent(opencv_mat mat, int xOffset, int yOffset, int width, int height)
+{
     auto cvMat = static_cast<cv::Mat*>(mat);
     if (!cvMat) {
         return OPENCV_ERROR_NULL_MATRIX;
     }
 
-    if (xOffset < 0 || yOffset < 0 || xOffset + width > cvMat->cols || yOffset + height > cvMat->rows) {
+    if (xOffset < 0 || yOffset < 0 || xOffset + width > cvMat->cols ||
+        yOffset + height > cvMat->rows) {
         return OPENCV_ERROR_OUT_OF_BOUNDS;
     }
 
@@ -372,22 +381,26 @@ int opencv_mat_clear_to_transparent(opencv_mat mat, int xOffset, int yOffset, in
         cv::Rect roi(xOffset, yOffset, width, height);
         if (cvMat->channels() == 4) {
             cvMat->operator()(roi).setTo(cv::Scalar(0, 0, 0, 0));
-        } else if (cvMat->channels() == 3) {
+        }
+        else if (cvMat->channels() == 3) {
             // For 3-channel images, we'll use black as "transparent"
             cvMat->operator()(roi).setTo(cv::Scalar(0, 0, 0));
-        } else {
+        }
+        else {
             return OPENCV_ERROR_INVALID_CHANNEL_COUNT;
         }
         return OPENCV_SUCCESS;
-    } catch (const cv::Exception& e) {
-        std::cerr << "OpenCV exception in opencv_mat_clear_to_transparent: " << e.what() << std::endl;
+    }
+    catch (const cv::Exception& e) {
+        std::cerr << "OpenCV exception in opencv_mat_clear_to_transparent: " << e.what()
+                  << std::endl;
         return OPENCV_ERROR_UNKNOWN;
     }
 }
 
 /**
  * @brief Blend source image with destination image using alpha blending.
- * 
+ *
  * @param src Pointer to the source OpenCV matrix.
  * @param dst Pointer to the destination OpenCV matrix.
  * @param xOffset X-coordinate offset in the destination image.
@@ -396,7 +409,13 @@ int opencv_mat_clear_to_transparent(opencv_mat mat, int xOffset, int yOffset, in
  * @param height Height of the region to copy.
  * @return int Error code.
  */
-int opencv_copy_to_region_with_alpha(opencv_mat src, opencv_mat dst, int xOffset, int yOffset, int width, int height) {
+int opencv_copy_to_region_with_alpha(opencv_mat src,
+                                     opencv_mat dst,
+                                     int xOffset,
+                                     int yOffset,
+                                     int width,
+                                     int height)
+{
     try {
         auto srcMat = static_cast<cv::Mat*>(src);
         auto dstMat = static_cast<cv::Mat*>(dst);
@@ -405,7 +424,8 @@ int opencv_copy_to_region_with_alpha(opencv_mat src, opencv_mat dst, int xOffset
             return OPENCV_ERROR_NULL_MATRIX;
         }
 
-        if (xOffset < 0 || yOffset < 0 || xOffset + width > dstMat->cols || yOffset + height > dstMat->rows) {
+        if (xOffset < 0 || yOffset < 0 || xOffset + width > dstMat->cols ||
+            yOffset + height > dstMat->rows) {
             return OPENCV_ERROR_OUT_OF_BOUNDS;
         }
 
@@ -419,7 +439,8 @@ int opencv_copy_to_region_with_alpha(opencv_mat src, opencv_mat dst, int xOffset
         cv::Mat srcResized;
         if (srcMat->size() != dstROI.size()) {
             cv::resize(*srcMat, srcResized, dstROI.size(), 0, 0, cv::INTER_LINEAR);
-        } else {
+        }
+        else {
             srcResized = *srcMat;
         }
 
@@ -432,17 +453,21 @@ int opencv_copy_to_region_with_alpha(opencv_mat src, opencv_mat dst, int xOffset
         cv::Mat src4, dst4;
         if (srcResized.channels() == 3) {
             cv::cvtColor(srcResized, src4, cv::COLOR_BGR2BGRA);
-        } else if (srcResized.channels() == 4) {
+        }
+        else if (srcResized.channels() == 4) {
             src4 = srcResized;
-        } else {
+        }
+        else {
             return OPENCV_ERROR_INVALID_CHANNEL_COUNT;
         }
 
         if (dstROI.channels() == 3) {
             cv::cvtColor(dstROI, dst4, cv::COLOR_BGR2BGRA);
-        } else if (dstROI.channels() == 4) {
+        }
+        else if (dstROI.channels() == 4) {
             dst4 = dstROI;
-        } else {
+        }
+        else {
             return OPENCV_ERROR_INVALID_CHANNEL_COUNT;
         }
 
@@ -462,7 +487,9 @@ int opencv_copy_to_region_with_alpha(opencv_mat src, opencv_mat dst, int xOffset
             cv::Mat srcChannelF, dstChannelF;
             srcChannels[i].convertTo(srcChannelF, CV_32F, 1.0 / 255.0);
             dstChannels[i].convertTo(dstChannelF, CV_32F, 1.0 / 255.0);
-            cv::Mat blended = (srcChannelF.mul(srcAlphaF) + dstChannelF.mul(dstAlphaF).mul(1.0f - srcAlphaF)) / outAlphaF;
+            cv::Mat blended =
+              (srcChannelF.mul(srcAlphaF) + dstChannelF.mul(dstAlphaF).mul(1.0f - srcAlphaF)) /
+              outAlphaF;
             blended.convertTo(dstChannels[i], CV_8U, 255.0);
         }
         outAlphaF.convertTo(dstChannels[3], CV_8U, 255.0);
@@ -472,18 +499,24 @@ int opencv_copy_to_region_with_alpha(opencv_mat src, opencv_mat dst, int xOffset
         // Convert back to original channel count if necessary
         if (dstROI.channels() == 3) {
             cv::cvtColor(dst4, dstROI, cv::COLOR_BGRA2BGR);
-        } else {
+        }
+        else {
             dst4.copyTo(dstROI);
         }
 
         return OPENCV_SUCCESS;
-    } catch (const cv::Exception& e) {
-        std::cerr << "OpenCV exception in opencv_copy_to_region_with_alpha: " << e.what() << std::endl;
+    }
+    catch (const cv::Exception& e) {
+        std::cerr << "OpenCV exception in opencv_copy_to_region_with_alpha: " << e.what()
+                  << std::endl;
         return OPENCV_ERROR_ALPHA_BLENDING_FAILED;
-    } catch (const std::exception& e) {
-        std::cerr << "Standard exception in opencv_copy_to_region_with_alpha: " << e.what() << std::endl;
+    }
+    catch (const std::exception& e) {
+        std::cerr << "Standard exception in opencv_copy_to_region_with_alpha: " << e.what()
+                  << std::endl;
         return OPENCV_ERROR_UNKNOWN;
-    } catch (...) {
+    }
+    catch (...) {
         std::cerr << "Unknown exception in opencv_copy_to_region_with_alpha" << std::endl;
         return OPENCV_ERROR_UNKNOWN;
     }
@@ -491,7 +524,7 @@ int opencv_copy_to_region_with_alpha(opencv_mat src, opencv_mat dst, int xOffset
 
 /**
  * @brief Copy source image to a rectangular region of the destination image.
- * 
+ *
  * @param src Pointer to the source OpenCV matrix.
  * @param dst Pointer to the destination OpenCV matrix.
  * @param xOffset X-coordinate of the top-left corner in the destination image.
@@ -500,7 +533,13 @@ int opencv_copy_to_region_with_alpha(opencv_mat src, opencv_mat dst, int xOffset
  * @param height Height of the region to copy.
  * @return int Error code.
  */
-int opencv_copy_to_region(opencv_mat src, opencv_mat dst, int xOffset, int yOffset, int width, int height) {
+int opencv_copy_to_region(opencv_mat src,
+                          opencv_mat dst,
+                          int xOffset,
+                          int yOffset,
+                          int width,
+                          int height)
+{
     try {
         auto srcMat = static_cast<cv::Mat*>(src);
         auto dstMat = static_cast<cv::Mat*>(dst);
@@ -509,7 +548,8 @@ int opencv_copy_to_region(opencv_mat src, opencv_mat dst, int xOffset, int yOffs
             return OPENCV_ERROR_NULL_MATRIX;
         }
 
-        if (xOffset < 0 || yOffset < 0 || xOffset + width > dstMat->cols || yOffset + height > dstMat->rows) {
+        if (xOffset < 0 || yOffset < 0 || xOffset + width > dstMat->cols ||
+            yOffset + height > dstMat->rows) {
             return OPENCV_ERROR_OUT_OF_BOUNDS;
         }
 
@@ -524,7 +564,8 @@ int opencv_copy_to_region(opencv_mat src, opencv_mat dst, int xOffset, int yOffs
         cv::Mat srcResized;
         if (srcMat->size() != dstROI.size()) {
             cv::resize(*srcMat, srcResized, dstROI.size(), 0, 0, cv::INTER_LINEAR);
-        } else {
+        }
+        else {
             srcResized = *srcMat;
         }
 
@@ -532,13 +573,17 @@ int opencv_copy_to_region(opencv_mat src, opencv_mat dst, int xOffset, int yOffs
         if (srcResized.channels() != dstROI.channels()) {
             if (srcResized.channels() == 3 && dstROI.channels() == 4) {
                 cv::cvtColor(srcResized, srcResized, cv::COLOR_BGR2BGRA);
-            } else if (srcResized.channels() == 4 && dstROI.channels() == 3) {
+            }
+            else if (srcResized.channels() == 4 && dstROI.channels() == 3) {
                 cv::cvtColor(srcResized, srcResized, cv::COLOR_BGRA2BGR);
-            } else if (srcResized.channels() == 1 && dstROI.channels() == 3) {
+            }
+            else if (srcResized.channels() == 1 && dstROI.channels() == 3) {
                 cv::cvtColor(srcResized, srcResized, cv::COLOR_GRAY2BGR);
-            } else if (srcResized.channels() == 1 && dstROI.channels() == 4) {
+            }
+            else if (srcResized.channels() == 1 && dstROI.channels() == 4) {
                 cv::cvtColor(srcResized, srcResized, cv::COLOR_GRAY2BGRA);
-            } else {
+            }
+            else {
                 return OPENCV_ERROR_INVALID_CHANNEL_COUNT;
             }
         }
@@ -547,13 +592,16 @@ int opencv_copy_to_region(opencv_mat src, opencv_mat dst, int xOffset, int yOffs
         srcResized.copyTo(dstROI);
 
         return OPENCV_SUCCESS;
-    } catch (const cv::Exception& e) {
+    }
+    catch (const cv::Exception& e) {
         std::cerr << "OpenCV exception in opencv_copy_to_region: " << e.what() << std::endl;
         return OPENCV_ERROR_COPY_FAILED;
-    } catch (const std::exception& e) {
+    }
+    catch (const std::exception& e) {
         std::cerr << "Standard exception in opencv_copy_to_region: " << e.what() << std::endl;
         return OPENCV_ERROR_UNKNOWN;
-    } catch (...) {
+    }
+    catch (...) {
         std::cerr << "Unknown exception in opencv_copy_to_region" << std::endl;
         return OPENCV_ERROR_UNKNOWN;
     }

--- a/opencv.hpp
+++ b/opencv.hpp
@@ -43,11 +43,25 @@ int opencv_decoder_get_height(const opencv_decoder d);
 int opencv_decoder_get_pixel_type(const opencv_decoder d);
 int opencv_decoder_get_orientation(const opencv_decoder d);
 bool opencv_decoder_read_data(opencv_decoder d, opencv_mat dst);
-int opencv_copy_to_region_with_alpha(opencv_mat src, opencv_mat dst, int xOffset, int yOffset, int width, int height);
-int opencv_copy_to_region(opencv_mat src, opencv_mat dst, int xOffset, int yOffset, int width, int height);
+int opencv_copy_to_region_with_alpha(opencv_mat src,
+                                     opencv_mat dst,
+                                     int xOffset,
+                                     int yOffset,
+                                     int width,
+                                     int height);
+int opencv_copy_to_region(opencv_mat src,
+                          opencv_mat dst,
+                          int xOffset,
+                          int yOffset,
+                          int width,
+                          int height);
 void opencv_mat_set_color(opencv_mat, int red, int green, int blue, int alpha);
 void opencv_mat_reset(opencv_mat mat);
-int opencv_mat_clear_to_transparent(opencv_mat mat, int xOffset, int yOffset, int width, int height);
+int opencv_mat_clear_to_transparent(opencv_mat mat,
+                                    int xOffset,
+                                    int yOffset,
+                                    int width,
+                                    int height);
 
 opencv_mat opencv_mat_create(int width, int height, int type);
 opencv_mat opencv_mat_create_from_data(int width,

--- a/thumbhash.cpp
+++ b/thumbhash.cpp
@@ -147,7 +147,7 @@ int thumbhash_encoder_encode(thumbhash_encoder e, const opencv_mat opaque_frame)
                 size_t orig_i = static_cast<size_t>(i * row_ratio);
                 size_t orig_j = static_cast<size_t>(j * col_ratio);
                 const cv::Vec4b& pixel = frame->at<cv::Vec4b>(orig_i, orig_j);
-                float alpha = static_cast<float>(pixel[3]) / 255.0f;                        // A
+                float alpha = static_cast<float>(pixel[3]) / 255.0f; // A
                 float b =
                   avg_b * (1.0f - alpha) + (alpha / 255.0f) * static_cast<float>(pixel[0]); // B
                 float g =

--- a/webp.cpp
+++ b/webp.cpp
@@ -36,9 +36,9 @@ struct webp_encoder_struct {
     uint32_t loop_count;
 
     // output fields
-    WebPMux* mux;                  // Used for still images
-    WebPAnimEncoder* anim;         // Used for animated images
-    WebPPicture picture;           // Picture for current/first frame
+    WebPMux* mux;          // Used for still images
+    WebPAnimEncoder* anim; // Used for animated images
+    WebPPicture picture;   // Picture for current/first frame
     int frame_count;
     int first_frame_delay;
     int first_frame_blend;
@@ -47,10 +47,10 @@ struct webp_encoder_struct {
     int first_frame_y_offset;
     uint8_t* dst;
     size_t dst_len;
-    int canvas_width;              // Width of the animation canvas
-    int canvas_height;             // Height of the animation canvas
-    bool is_animation;             // Whether we're encoding an animation
-    int timestamp_ms;              // Current timestamp in milliseconds
+    int canvas_width;  // Width of the animation canvas
+    int canvas_height; // Height of the animation canvas
+    bool is_animation; // Whether we're encoding an animation
+    int timestamp_ms;  // Current timestamp in milliseconds
 };
 
 /**
@@ -61,7 +61,7 @@ struct webp_encoder_struct {
 webp_decoder webp_decoder_create(const opencv_mat buf)
 {
     auto cvMat = static_cast<const cv::Mat*>(buf);
-    WebPData src = { cvMat->data, cvMat->total() };
+    WebPData src = {cvMat->data, cvMat->total()};
     WebPMux* mux = WebPMuxCreate(&src, 0);
 
     if (!mux) {
@@ -120,7 +120,8 @@ webp_decoder webp_decoder_create(const opencv_mat buf)
             d->loop_count = anim_params.loop_count;
         }
         d->has_animation = true;
-    } else {
+    }
+    else {
         // For static images, ensure duration is 0
         d->total_duration = 0;
     }
@@ -261,7 +262,7 @@ int webp_decoder_get_total_duration(const webp_decoder d)
  */
 size_t webp_decoder_get_icc(const webp_decoder d, void* dst, size_t dst_len)
 {
-    WebPData icc = { nullptr, 0 };
+    WebPData icc = {nullptr, 0};
     auto res = WebPMuxGetChunk(d->mux, "ICCP", &icc);
     if (icc.size > 0 && res == WEBP_MUX_OK) {
         if (icc.size <= dst_len) {
@@ -279,7 +280,7 @@ size_t webp_decoder_get_icc(const webp_decoder d, void* dst, size_t dst_len)
  */
 int webp_decoder_has_more_frames(webp_decoder d)
 {
-     return d->current_frame_index < d->total_frame_count;
+    return d->current_frame_index < d->total_frame_count;
 }
 
 /**
@@ -292,7 +293,8 @@ void webp_decoder_advance_frame(webp_decoder d)
 }
 
 /**
- * Decodes the current frame of the WebP image and stores the decoded image in the provided OpenCV matrix.
+ * Decodes the current frame of the WebP image and stores the decoded image in the provided OpenCV
+ * matrix.
  * @param d The webp_decoder_struct pointer.
  * @param mat The OpenCV matrix to store the decoded image.
  * @return True if the frame was successfully decoded, false otherwise.
@@ -305,7 +307,7 @@ bool webp_decoder_decode(const webp_decoder d, opencv_mat mat)
 
     WebPMuxFrameInfo frame;
     WebPMuxError mux_error = WebPMuxGetFrame(d->mux, d->current_frame_index, &frame);
-    
+
     if (mux_error != WEBP_MUX_OK) {
         return false;
     }
@@ -333,16 +335,22 @@ bool webp_decoder_decode(const webp_decoder d, opencv_mat mat)
     // Decode the frame
     uint8_t* res = nullptr;
     switch (webp_decoder_get_pixel_type(d)) {
-        case CV_8UC4:
-            res = WebPDecodeBGRAInto(frame.bitstream.bytes, frame.bitstream.size,
-                                     d->decode_buffer, d->decode_buffer_size, row_size);
-            break;
-        case CV_8UC3:
-            res = WebPDecodeBGRInto(frame.bitstream.bytes, frame.bitstream.size,
-                                d->decode_buffer, d->decode_buffer_size, row_size);
-            break;
-        default:
-            return false;
+    case CV_8UC4:
+        res = WebPDecodeBGRAInto(frame.bitstream.bytes,
+                                 frame.bitstream.size,
+                                 d->decode_buffer,
+                                 d->decode_buffer_size,
+                                 row_size);
+        break;
+    case CV_8UC3:
+        res = WebPDecodeBGRInto(frame.bitstream.bytes,
+                                frame.bitstream.size,
+                                d->decode_buffer,
+                                d->decode_buffer_size,
+                                row_size);
+        break;
+    default:
+        return false;
     }
 
     if (res) {
@@ -360,7 +368,8 @@ bool webp_decoder_decode(const webp_decoder d, opencv_mat mat)
 void webp_decoder_release(webp_decoder d)
 {
     if (d) {
-        if (d->mux) WebPMuxDelete(d->mux);
+        if (d->mux)
+            WebPMuxDelete(d->mux);
         delete[] d->decode_buffer;
         delete d;
     }
@@ -376,7 +385,12 @@ void webp_decoder_release(webp_decoder d)
  * @param gif_encode_paletted Whether to use delta palette for encoding of GIF source images.
  * @return A pointer to the created webp_encoder_struct, or nullptr if creation failed.
  */
-webp_encoder webp_encoder_create(void* buf, size_t buf_len, const void* icc, size_t icc_len, uint32_t bgcolor, int loop_count)
+webp_encoder webp_encoder_create(void* buf,
+                                 size_t buf_len,
+                                 const void* icc,
+                                 size_t icc_len,
+                                 uint32_t bgcolor,
+                                 int loop_count)
 {
     webp_encoder e = new struct webp_encoder_struct();
     memset(e, 0, sizeof(struct webp_encoder_struct));
@@ -419,7 +433,15 @@ webp_encoder webp_encoder_create(void* buf, size_t buf_len, const void* icc, siz
  * @param y_offset The y-offset for the current frame.
  * @return The size of the encoded WebP data, or 0 if encoding failed.
  */
-size_t webp_encoder_write(webp_encoder e, const opencv_mat src, const int* opt, size_t opt_len, int delay, int blend, int dispose, int x_offset, int y_offset)
+size_t webp_encoder_write(webp_encoder e,
+                          const opencv_mat src,
+                          const int* opt,
+                          size_t opt_len,
+                          int delay,
+                          int blend,
+                          int dispose,
+                          int x_offset,
+                          int y_offset)
 {
     if (!e) {
         return 0;
@@ -437,40 +459,40 @@ size_t webp_encoder_write(webp_encoder e, const opencv_mat src, const int* opt, 
             int key = opt[i];
             int value = opt[i + 1];
             float quality;
-            
+
             switch (key) {
-                case CV_IMWRITE_WEBP_QUALITY:
-                    quality = std::max(1.0f, (float)value);
-                    config.quality = std::min(100.0f, quality);
-                    config.lossless = (quality > 100.0f);
-                    break;
-                case WEBP_METHOD:
-                    config.method = value;
-                    break;
-                case WEBP_FILTER_STRENGTH:
-                    config.filter_strength = value;
-                    break;
-                case WEBP_FILTER_TYPE:
-                    config.filter_type = value;
-                    break;
-                case WEBP_AUTOFILTER:
-                    config.autofilter = value;
-                    break;
-                case WEBP_PARTITIONS:
-                    config.partitions = value;
-                    break;
-                case WEBP_SEGMENTS:
-                    config.segments = value;
-                    break;
-                case WEBP_PREPROCESSING:
-                    config.preprocessing = value;
-                    break;
-                case WEBP_THREAD_LEVEL:
-                    config.thread_level = value;
-                    break;
-                case WEBP_PALETTE:
-                    config.use_delta_palette = value;
-                    break;
+            case CV_IMWRITE_WEBP_QUALITY:
+                quality = std::max(1.0f, (float)value);
+                config.quality = std::min(100.0f, quality);
+                config.lossless = (quality > 100.0f);
+                break;
+            case WEBP_METHOD:
+                config.method = value;
+                break;
+            case WEBP_FILTER_STRENGTH:
+                config.filter_strength = value;
+                break;
+            case WEBP_FILTER_TYPE:
+                config.filter_type = value;
+                break;
+            case WEBP_AUTOFILTER:
+                config.autofilter = value;
+                break;
+            case WEBP_PARTITIONS:
+                config.partitions = value;
+                break;
+            case WEBP_SEGMENTS:
+                config.segments = value;
+                break;
+            case WEBP_PREPROCESSING:
+                config.preprocessing = value;
+                break;
+            case WEBP_THREAD_LEVEL:
+                config.thread_level = value;
+                break;
+            case WEBP_PALETTE:
+                config.use_delta_palette = value;
+                break;
             }
         }
     }
@@ -501,41 +523,46 @@ size_t webp_encoder_write(webp_encoder e, const opencv_mat src, const int* opt, 
                 if (mux != NULL) {
                     // Add ICC profile if it exists
                     if (e->icc && e->icc_len > 0) {
-                        WebPData icc_data = { e->icc, e->icc_len };
+                        WebPData icc_data = {e->icc, e->icc_len};
                         WebPMuxSetChunk(mux, "ICCP", &icc_data, 1);
                     }
-                    
+
                     // Get the final data with ICC profile
                     WebPData final_data;
                     if (WebPMuxAssemble(mux, &final_data) == WEBP_MUX_OK) {
                         if (final_data.size <= e->dst_len) {
                             memcpy(e->dst, final_data.bytes, final_data.size);
                             size = final_data.size;
-                        } else {
-                            fprintf(stderr, "Error: Final encoded size (%zu) exceeds buffer size (%zu)\n",
-                                    final_data.size, e->dst_len);
+                        }
+                        else {
+                            fprintf(stderr,
+                                    "Error: Final encoded size (%zu) exceeds buffer size (%zu)\n",
+                                    final_data.size,
+                                    e->dst_len);
                         }
                         WebPDataClear(&final_data);
                     }
                     WebPMuxDelete(mux);
                 }
                 WebPDataClear(&webp_data);
-            } else {
-                fprintf(stderr, "Failed to assemble animation: %s\n",
-                        WebPAnimEncoderGetError(e->anim));
+            }
+            else {
+                fprintf(
+                  stderr, "Failed to assemble animation: %s\n", WebPAnimEncoderGetError(e->anim));
             }
             WebPAnimEncoderDelete(e->anim);
             e->anim = nullptr;
-        } else {
+        }
+        else {
             // Finalize still image
-            WebPData out_mux = { nullptr, 0 };
-            
+            WebPData out_mux = {nullptr, 0};
+
             // Add ICC profile if it exists
             if (e->icc && e->icc_len > 0) {
-                WebPData icc_data = { e->icc, e->icc_len };
+                WebPData icc_data = {e->icc, e->icc_len};
                 WebPMuxSetChunk(e->mux, "ICCP", &icc_data, 1);
             }
-            
+
             if (WebPMuxAssemble(e->mux, &out_mux) == WEBP_MUX_OK) {
                 if (out_mux.size <= e->dst_len) {
                     memcpy(e->dst, out_mux.bytes, out_mux.size);
@@ -581,7 +608,7 @@ size_t webp_encoder_write(webp_encoder e, const opencv_mat src, const int* opt, 
         e->picture.width = mat->cols;
         e->picture.height = mat->rows;
         e->picture.use_argb = 1;
-        
+
         if (!WebPPictureAlloc(&e->picture)) {
             return 0;
         }
@@ -589,7 +616,8 @@ size_t webp_encoder_write(webp_encoder e, const opencv_mat src, const int* opt, 
         size_t size = 0;
         if (mat->channels() == 3) {
             size = WebPPictureImportBGR(&e->picture, mat->data, mat->step);
-        } else {
+        }
+        else {
             size = WebPPictureImportBGRA(&e->picture, mat->data, mat->step);
         }
 
@@ -605,10 +633,11 @@ size_t webp_encoder_write(webp_encoder e, const opencv_mat src, const int* opt, 
         e->canvas_width = mat->cols;
         e->canvas_height = mat->rows;
         e->timestamp_ms = 0;
-        
+
         WebPAnimEncoderOptions anim_config;
         if (!WebPAnimEncoderOptionsInit(&anim_config)) {
-            fprintf(stderr, "Failed to initialize animation encoder options: %s\n",
+            fprintf(stderr,
+                    "Failed to initialize animation encoder options: %s\n",
                     WebPAnimEncoderGetError(e->anim));
             return 0;
         }
@@ -624,12 +653,14 @@ size_t webp_encoder_write(webp_encoder e, const opencv_mat src, const int* opt, 
 
         // Add first frame from stored picture
         if (WebPAnimEncoderAdd(e->anim, &e->picture, e->timestamp_ms, &config) != 1) {
-            fprintf(stderr, "Failed to add first frame to animation at timestamp %d: %s\n",
-                    e->timestamp_ms, WebPAnimEncoderGetError(e->anim));
+            fprintf(stderr,
+                    "Failed to add first frame to animation at timestamp %d: %s\n",
+                    e->timestamp_ms,
+                    WebPAnimEncoderGetError(e->anim));
             return 0;
         }
-        e->timestamp_ms += e->first_frame_delay;  // Add first frame delay to timestamp
-        WebPPictureFree(&e->picture);  // Free the stored first frame
+        e->timestamp_ms += e->first_frame_delay; // Add first frame delay to timestamp
+        WebPPictureFree(&e->picture);            // Free the stored first frame
     }
 
     // Handle current frame
@@ -643,15 +674,15 @@ size_t webp_encoder_write(webp_encoder e, const opencv_mat src, const int* opt, 
         frame.use_argb = 1;
 
         if (!WebPPictureAlloc(&frame)) {
-            fprintf(stderr, "Failed to allocate picture for frame %d\n",
-                    e->frame_count);
+            fprintf(stderr, "Failed to allocate picture for frame %d\n", e->frame_count);
             return 0;
         }
 
         // Import the frame
         if (mat->channels() == 3) {
             size = WebPPictureImportBGR(&frame, mat->data, mat->step);
-        } else {
+        }
+        else {
             size = WebPPictureImportBGRA(&frame, mat->data, mat->step);
         }
 
@@ -662,28 +693,39 @@ size_t webp_encoder_write(webp_encoder e, const opencv_mat src, const int* opt, 
 
         // Add frame to animation
         if (WebPAnimEncoderAdd(e->anim, &frame, e->timestamp_ms, &config) != 1) {
-            fprintf(stderr, "Failed to add frame %d to animation at timestamp %d: %s\n",
-                    e->frame_count, e->timestamp_ms, WebPAnimEncoderGetError(e->anim));
+            fprintf(stderr,
+                    "Failed to add frame %d to animation at timestamp %d: %s\n",
+                    e->frame_count,
+                    e->timestamp_ms,
+                    WebPAnimEncoderGetError(e->anim));
             WebPPictureFree(&frame);
             return 0;
         }
         e->timestamp_ms += delay;
         WebPPictureFree(&frame);
-    } else {
+    }
+    else {
         // Handle single frame
         uint8_t* out_picture = nullptr;
 
         if (config.lossless) {
             if (mat->channels() == 3) {
-                size = WebPEncodeLosslessBGR(mat->data, mat->cols, mat->rows, mat->step, &out_picture);
-            } else {
-                size = WebPEncodeLosslessBGRA(mat->data, mat->cols, mat->rows, mat->step, &out_picture);
+                size =
+                  WebPEncodeLosslessBGR(mat->data, mat->cols, mat->rows, mat->step, &out_picture);
             }
-        } else {
+            else {
+                size =
+                  WebPEncodeLosslessBGRA(mat->data, mat->cols, mat->rows, mat->step, &out_picture);
+            }
+        }
+        else {
             if (mat->channels() == 3) {
-                size = WebPEncodeBGR(mat->data, mat->cols, mat->rows, mat->step, config.quality, &out_picture);
-            } else {
-                size = WebPEncodeBGRA(mat->data, mat->cols, mat->rows, mat->step, config.quality, &out_picture);
+                size = WebPEncodeBGR(
+                  mat->data, mat->cols, mat->rows, mat->step, config.quality, &out_picture);
+            }
+            else {
+                size = WebPEncodeBGRA(
+                  mat->data, mat->cols, mat->rows, mat->step, config.quality, &out_picture);
             }
         }
 
@@ -691,7 +733,7 @@ size_t webp_encoder_write(webp_encoder e, const opencv_mat src, const int* opt, 
             return 0;
         }
 
-        WebPData picture = { out_picture, size };
+        WebPData picture = {out_picture, size};
         WebPMuxError mux_error = WebPMuxSetImage(e->mux, &picture, 1);
         WebPFree(out_picture);
 
@@ -705,7 +747,7 @@ size_t webp_encoder_write(webp_encoder e, const opencv_mat src, const int* opt, 
         e->first_frame_dispose = dispose;
         e->first_frame_x_offset = x_offset;
         e->first_frame_y_offset = y_offset;
-        e->timestamp_ms = 0;  // Initialize timestamp for first frame
+        e->timestamp_ms = 0; // Initialize timestamp for first frame
     }
 
     e->frame_count++;

--- a/webp.hpp
+++ b/webp.hpp
@@ -53,8 +53,21 @@ bool webp_decoder_decode(webp_decoder d, opencv_mat mat);
 //----------------------
 // Encoder Management
 //----------------------
-webp_encoder webp_encoder_create(void* buf, size_t buf_len, const void* icc, size_t icc_len, uint32_t bgcolor, int loop_count);
-size_t webp_encoder_write(webp_encoder e, const opencv_mat src, const int* opt, size_t opt_len, int delay, int blend, int dispose, int x_offset, int y_offset);
+webp_encoder webp_encoder_create(void* buf,
+                                 size_t buf_len,
+                                 const void* icc,
+                                 size_t icc_len,
+                                 uint32_t bgcolor,
+                                 int loop_count);
+size_t webp_encoder_write(webp_encoder e,
+                          const opencv_mat src,
+                          const int* opt,
+                          size_t opt_len,
+                          int delay,
+                          int blend,
+                          int dispose,
+                          int x_offset,
+                          int y_offset);
 void webp_encoder_release(webp_encoder e);
 size_t webp_encoder_flush(webp_encoder e);
 void webp_decoder_advance_frame(webp_decoder d);


### PR DESCRIPTION
Add a GitHub action triggered on push and PR to automatically run clang-format on cpp and hpp files at root only

Old state doesn't enforce clang-format but we provide a set of rules. This will ensure the code is always push according to these guidelines.

All cpp and hpp files modified here are the result of running clang-format