### PR TITLE
fix: Restore backward compatible handling of unspecified GIF disposal method.

### DIFF
--- a/giflib.cpp
+++ b/giflib.cpp
@@ -146,7 +146,7 @@ int giflib_decoder_get_prev_frame_disposal(const giflib_decoder d)
     case DISPOSE_PREVIOUS:
         return GIF_DISPOSE_PREVIOUS;
     default: // DISPOSAL_UNSPECIFIED
-        return GIF_DISPOSE_NONE;
+        return GIF_DISPOSE_BACKGROUND;
     }
 }
 


### PR DESCRIPTION
PR #244 added support for the "Restore Previous" GIF disposal method but also changed how unspecified disposal methods (0) were handled. Previously, `DISPOSAL_UNSPECIFIED` was treated as `GIF_DISPOSE_BACKGROUND` which cleared frames to background color, but it was changed to `GIF_DISPOSE_NONE` which caused frame compositing instead. Though this is compliant with the spec, it differs from the behavior assumed by many browsers.

This change restores the original behavior to maintain backward compatibility with existing GIFs that rely on the previous interpretation, fixing animation issues in Discord clients where frames were being incorrectly composited.