### PR TITLE
Revert "fix: Restore backward compatible handling of unspecified GIF disposal method"

### DIFF
--- a/giflib.cpp
+++ b/giflib.cpp
@@ -146,7 +146,7 @@ int giflib_decoder_get_prev_frame_disposal(const giflib_decoder d)
     case DISPOSE_PREVIOUS:
         return GIF_DISPOSE_PREVIOUS;
     default: // DISPOSAL_UNSPECIFIED
-        return GIF_DISPOSE_BACKGROUND;
+        return GIF_DISPOSE_NONE;
     }
 }
 


### PR DESCRIPTION
This reverts commit 98065590f4eeb1e9354616abea972f760febfeae.

There's a different underlying issue that will be addressed in a separate PR.