### PR TITLE
fix: Preserve GIF transparent color across frames

### DIFF
--- a/giflib.cpp
+++ b/giflib.cpp
@@ -146,7 +146,7 @@ int giflib_decoder_get_prev_frame_disposal(const giflib_decoder d)
     case DISPOSE_PREVIOUS:
         return GIF_DISPOSE_PREVIOUS;
     default: // DISPOSAL_UNSPECIFIED
-        return GIF_DISPOSE_BACKGROUND;
+        return GIF_DISPOSE_NONE;
     }
 }
 
@@ -833,12 +833,6 @@ static bool giflib_encoder_setup_frame(giflib_encoder e, const giflib_decoder d)
     // Fix GCB disposal mode for DISPOSAL_UNSPECIFIED
     GraphicsControlBlock gcb;
     if (giflib_get_frame_gcb(e->gif, &gcb)) {
-        if (gcb.DisposalMode == DISPOSAL_UNSPECIFIED) {
-            // For backward compatibility, treat DISPOSAL_UNSPECIFIED as DISPOSE_BACKGROUND
-            gcb.DisposalMode = DISPOSE_BACKGROUND;
-            giflib_set_frame_gcb(e->gif, &gcb);
-        }
-        
         // GIF transparency optimization: If the transparent color matches the background color,
         // we can remove the transparency, but only when the background is fully opaque (alpha=255).
         // This prevents incorrect removal of transparency when the background has transparency.


### PR DESCRIPTION
## Summary
This PR addresses an issue where transparency information from GIF files was being discarded during the decoding process, resulting in incorrect background and transparency color values in GIF-to-GIF conversions.

## Change
- Removed the default initialization of `TransparentColor = NO_TRANSPARENT_COLOR` in the `giflib_get_frame_gcb` function
- This allows the original transparency color index from the source GIF to be preserved when reading GraphicsControlBlock information
- Added safeguards against removing transparency when background has partial transparency
- Restores use of No Dispose for case where disposal method is unspecified

## Impact
- Background colors and transparency values are now correctly preserved in round-trip GIF-to-GIF conversions
- Maintains transparency information as specified in the original GIF files

 ## Testing
Analysis of GIF frame data shows that this change correctly preserves the original background color while the production version incorrectly defaults to black.

### Source
![orcouldyou](https://github.com/user-attachments/assets/171f68b2-0140-47ce-a274-df1bf8127d31)

### Development (this branch) version
![orcouldyou-dev](https://github.com/user-attachments/assets/957592eb-2132-4bd4-b3ab-df3aab16fd71)


### Stable (prod) version
![orcouldyou-prod](https://github.com/user-attachments/assets/82ea87f3-a538-4fcc-9043-69eb71397f43)


Extracted background, transparency, and dispose data for a source image against images from created from this development branch and stable:

```
  # Extract background and transparency info from source file
  identify -verbose "orcouldyou.gif" | grep -iE "(background color:|transparent color:|dispos)" > source-identify.info

  # Extract info from production version (incorrect)
  identify -verbose "orcouldyou-prod.gif" | grep -iE "(background color:|transparent color:|dispos)" > prod-identify.info

  # Extract info from development version (correct)
  identify -verbose "orcouldyou-dev.gif" | grep -iE "(background color:|transparent color:|dispos)" > dev-identify.info

```

I then compared that data for the dev and stable (prod) branches against the source. The stable prod branch is mangling the background and transparent color, making them different from the source.
```
→ diff prod-identify.info source-identify.info
1c1
<   Background color: black
---
>   Background color: white
3,70c3,70
<   Background color: black
<   Transparent color: srgba(255,255,255,0)
<   Background color: black
<   Transparent color: srgba(255,255,255,0)
<   Background color: black
<   Transparent color: srgba(255,255,255,0)
<   Background color: black
<   Transparent color: srgba(255,255,255,0)
<   Background color: black
<   Transparent color: srgba(255,255,255,0)
<   Background color: black
<   Transparent color: srgba(255,255,255,0)
<   Background color: black
<   Transparent color: srgba(255,255,255,0)
<   Background color: black
<   Transparent color: srgba(255,255,255,0)
<   Background color: black
<   Transparent color: srgba(255,255,255,0)
<   Background color: black
<   Transparent color: srgba(255,255,255,0)
<   Background color: black
<   Transparent color: srgba(255,255,255,0)
<   Background color: black
<   Transparent color: srgba(255,255,255,0)
<   Background color: black
<   Transparent color: srgba(255,255,255,0)
<   Background color: black
<   Transparent color: srgba(255,255,255,0)
<   Background color: black
<   Transparent color: srgba(255,255,255,0)
<   Background color: black
<   Transparent color: srgba(255,255,255,0)
<   Background color: black
<   Transparent color: srgba(255,255,255,0)
<   Background color: black
<   Transparent color: srgba(255,255,255,0)
<   Background color: black
<   Transparent color: srgba(255,255,255,0)
<   Background color: black
<   Transparent color: srgba(255,255,255,0)
<   Background color: black
<   Transparent color: srgba(255,255,255,0)
<   Background color: black
<   Transparent color: srgba(255,255,255,0)
<   Background color: black
<   Transparent color: srgba(255,255,255,0)
<   Background color: black
<   Transparent color: srgba(255,255,255,0)
<   Background color: black
<   Transparent color: srgba(255,255,255,0)
<   Background color: black
<   Transparent color: srgba(255,255,255,0)
<   Background color: black
<   Transparent color: srgba(255,255,255,0)
<   Background color: black
<   Transparent color: srgba(255,255,255,0)
<   Background color: black
<   Transparent color: srgba(255,255,255,0)
<   Background color: black
<   Transparent color: srgba(255,255,255,0)
<   Background color: black
<   Transparent color: srgba(255,255,255,0)
<   Background color: black
<   Transparent color: srgba(255,255,255,0)
<   Background color: black
<   Transparent color: srgba(255,255,255,0)
<   Background color: black
<   Transparent color: srgba(255,255,255,0)
---
>   Background color: white
>   Transparent color: black
>   Background color: white
>   Transparent color: black
>   Background color: white
>   Transparent color: black
>   Background color: white
>   Transparent color: black
>   Background color: white
>   Transparent color: black
>   Background color: white
>   Transparent color: black
>   Background color: white
>   Transparent color: black
>   Background color: white
>   Transparent color: black
>   Background color: white
>   Transparent color: black
>   Background color: white
>   Transparent color: black
>   Background color: white
>   Transparent color: black
>   Background color: white
>   Transparent color: black
>   Background color: white
>   Transparent color: black
>   Background color: white
>   Transparent color: black
>   Background color: white
>   Transparent color: black
>   Background color: white
>   Transparent color: black
>   Background color: white
>   Transparent color: black
>   Background color: white
>   Transparent color: black
>   Background color: white
>   Transparent color: black
>   Background color: white
>   Transparent color: black
>   Background color: white
>   Transparent color: black
>   Background color: white
>   Transparent color: black
>   Background color: white
>   Transparent color: black
>   Background color: white
>   Transparent color: black
>   Background color: white
>   Transparent color: black
>   Background color: white
>   Transparent color: black
>   Background color: white
>   Transparent color: black
>   Background color: white
>   Transparent color: black
>   Background color: white
>   Transparent color: black
>   Background color: white
>   Transparent color: black
>   Background color: white
>   Transparent color: black
>   Background color: white
>   Transparent color: black
>   Background color: white
>   Transparent color: black
>   Background color: white
>   Transparent color: black

```

```
→ diff dev-identify.info source-identify.info
<empty>
```

## Technical Details
The issue was that we were unconditionally initializing the GraphicsControlBlock's `TransparentColor` field to `-1` (no transparency) before reading the actual GCB data from extension blocks. This inadvertently caused the loss of transparency information when no specific transparency data was present in the GIF's extension blocks. As far as I can tell, this issue has always existed in Lilliput.