### PR TITLE
fix: Prevent color corruption when mixing local and global GIF palettes

### DIFF
--- a/giflib.cpp
+++ b/giflib.cpp
@@ -839,7 +839,10 @@ static bool giflib_encoder_setup_frame(giflib_encoder e, const giflib_decoder d)
         if (gcb.TransparentColor != NO_TRANSPARENT_COLOR) {
             ColorMapObject* color_map = e->frame_color_map ? e->frame_color_map : e->gif->SColorMap;
             
+            // Only perform this optimization when using the global color map to avoid
+            // index mismatches between local and global palettes
             if (color_map && 
+                !e->frame_color_map &&
                 gcb.TransparentColor == e->gif->SBackGroundColor && 
                 d->bg_alpha == 255) {
                 gcb.TransparentColor = NO_TRANSPARENT_COLOR;


### PR DESCRIPTION
## Summary
Fixes a color corruption issue in animated GIFs where frames with local color palettes would display incorrect colors in Discord and other viewers.

## Problem
The issue was introduced in commit 52ba7f4 where transparency optimization logic incorrectly compared color indices from different color maps:
- `gcb.TransparentColor` refers to an index in the current frame's color map (local or global)
- `e->gif->SBackGroundColor` refers to an index in the global color map

When a frame used a local color map, these indices could point to completely different colors, but the code incorrectly assumed they referenced the same palette. This caused transparency to be incorrectly removed, leading to visible color corruption.

## Solution
Added a check `\!e->frame_color_map` to only perform the transparency optimization when using the global color map, preventing index mismatches between local and global palettes.

## Testing
- All existing tests pass
- Verified fix with the problematic GIF reported by Discord users
- Re-encoded GIFs now display correctly without color corruption

## Files Changed
- `giflib.cpp`: Added palette type check in transparency optimization logic

Resolves the regression reported by Discord users where GIFs processed by Lilliput showed "colors completely warped, flashing wildly" during playback.