### PR TITLE
feat: Add video and audio codec metadata reporting

### DIFF
--- a/avcodec.cpp
+++ b/avcodec.cpp
@@ -403,6 +403,59 @@ const char* avcodec_decoder_get_description(const avcodec_decoder d)
     return "";
 }
 
+const char* avcodec_decoder_get_video_codec(const avcodec_decoder d)
+{
+    if (!d || !d->codec) {
+        return "Unknown";
+    }
+    
+    switch (d->codec->codec_id) {
+    case AV_CODEC_ID_H264:
+        return "H264";
+    case AV_CODEC_ID_HEVC:
+        return "HEVC";
+    case AV_CODEC_ID_AV1:
+        return "AV1";
+    case AV_CODEC_ID_VP8:
+        return "VP8";
+    case AV_CODEC_ID_VP9:
+        return "VP9";
+    case AV_CODEC_ID_MPEG4:
+        return "MPEG4";
+    default:
+        return "Unknown";
+    }
+}
+
+const char* avcodec_decoder_get_audio_codec(const avcodec_decoder d)
+{
+    if (!d || !d->container) {
+        return "Unknown";
+    }
+    
+    for (unsigned int i = 0; i < d->container->nb_streams; i++) {
+        AVStream* stream = d->container->streams[i];
+        if (stream->codecpar->codec_type == AVMEDIA_TYPE_AUDIO) {
+            switch (stream->codecpar->codec_id) {
+            case AV_CODEC_ID_AAC:
+                return "AAC";
+            case AV_CODEC_ID_MP3:
+                return "MP3";
+            case AV_CODEC_ID_FLAC:
+                return "FLAC";
+            case AV_CODEC_ID_VORBIS:
+                return "Vorbis";
+            case AV_CODEC_ID_OPUS:
+                return "Opus";
+            default:
+                return "Unknown";
+            }
+        }
+    }
+    
+    return "Unknown";
+}
+
 bool avcodec_decoder_has_subtitles(const avcodec_decoder d)
 {
     for (unsigned int i = 0; i < d->container->nb_streams; i++) {

--- a/avcodec.go
+++ b/avcodec.go
@@ -114,6 +114,16 @@ func (d *avCodecDecoder) ICC() []byte {
 	return iccDst[:iccLength]
 }
 
+// VideoCodec returns the video codec name (H264, HEVC, AV1, VP8, VP9, MPEG4, or Unknown).
+func (d *avCodecDecoder) VideoCodec() string {
+	return C.GoString(C.avcodec_decoder_get_video_codec(d.decoder))
+}
+
+// AudioCodec returns the audio codec name (AAC, MP3, FLAC, Vorbis, Opus, or Unknown).
+func (d *avCodecDecoder) AudioCodec() string {
+	return C.GoString(C.avcodec_decoder_get_audio_codec(d.decoder))
+}
+
 // Duration returns the total duration of the media content.
 func (d *avCodecDecoder) Duration() time.Duration {
 	return time.Duration(float64(C.avcodec_decoder_get_duration(d.decoder)) * float64(time.Second))

--- a/avcodec.hpp
+++ b/avcodec.hpp
@@ -21,6 +21,8 @@ bool avcodec_decoder_decode(const avcodec_decoder d, opencv_mat mat);
 bool avcodec_decoder_is_streamable(const opencv_mat buf);
 bool avcodec_decoder_has_subtitles(const avcodec_decoder d);
 const char* avcodec_decoder_get_description(const avcodec_decoder d);
+const char* avcodec_decoder_get_video_codec(const avcodec_decoder d);
+const char* avcodec_decoder_get_audio_codec(const avcodec_decoder d);
 int avcodec_decoder_get_icc(const avcodec_decoder d, void* dest, size_t dest_len);
 
 #ifdef __cplusplus

--- a/avif.go
+++ b/avif.go
@@ -122,6 +122,14 @@ func (d *avifDecoder) LoopCount() int {
 	return int(C.avif_decoder_get_loop_count(d.decoder))
 }
 
+func (d *avifDecoder) VideoCodec() string {
+	return "AV1"
+}
+
+func (d *avifDecoder) AudioCodec() string {
+	return "Unknown"
+}
+
 func (d *avifDecoder) IsAnimated() bool {
 	return int(C.avif_decoder_get_num_frames(d.decoder)) > 1
 }

--- a/examples/main.go
+++ b/examples/main.go
@@ -68,6 +68,8 @@ func main() {
 	fmt.Printf("file type: %s\n", decoder.Description())
 	fmt.Printf("%dpx x %dpx\n", header.Width(), header.Height())
 	fmt.Printf("content length: %d\n", header.ContentLength())
+	fmt.Printf("video codec: %s\n", decoder.VideoCodec())
+	fmt.Printf("audio codec: %s\n", decoder.AudioCodec())
 
 	if decoder.Duration() != 0 {
 		fmt.Printf("duration: %.2f s\n", float64(decoder.Duration())/float64(time.Second))

--- a/giflib.go
+++ b/giflib.go
@@ -159,6 +159,16 @@ func (d *gifDecoder) LoopCount() int {
 	return d.loopCount
 }
 
+// VideoCodec returns "Unknown" since GIF is not a video codec container.
+func (d *gifDecoder) VideoCodec() string {
+	return "Unknown"
+}
+
+// AudioCodec returns "Unknown" since GIF does not support audio.
+func (d *gifDecoder) AudioCodec() string {
+	return "Unknown"
+}
+
 // FrameCount returns the total number of frames in the GIF.
 func (d *gifDecoder) FrameCount() int {
 	d.readAnimationInfo()

--- a/lilliput.go
+++ b/lilliput.go
@@ -67,6 +67,12 @@ type Decoder interface {
 
 	// LoopCount() returns the number of loops in the image
 	LoopCount() int
+
+	// VideoCodec returns the video codec name (H264, HEVC, AV1, VP8, VP9, MPEG4, or Unknown)
+	VideoCodec() string
+
+	// AudioCodec returns the audio codec name (AAC, MP3, FLAC, Vorbis, Opus, or Unknown)
+	AudioCodec() string
 }
 
 // An Encoder compresses raw pixel data into a well-known image type.

--- a/opencv.go
+++ b/opencv.go
@@ -661,6 +661,14 @@ func (d *openCVDecoder) LoopCount() int {
 	return 0 // loop indefinitely
 }
 
+func (d *openCVDecoder) VideoCodec() string {
+	return "Unknown"
+}
+
+func (d *openCVDecoder) AudioCodec() string {
+	return "Unknown"
+}
+
 func (d *openCVDecoder) HasSubtitles() bool {
 	return false
 }

--- a/webp.go
+++ b/webp.go
@@ -113,6 +113,16 @@ func (d *webpDecoder) LoopCount() int {
 	return int(C.webp_decoder_get_loop_count(d.decoder))
 }
 
+// VideoCodec returns "VP8" since WebP uses VP8 compression internally.
+func (d *webpDecoder) VideoCodec() string {
+	return "VP8"
+}
+
+// AudioCodec returns "Unknown" since WebP does not support audio.
+func (d *webpDecoder) AudioCodec() string {
+	return "Unknown"
+}
+
 // DecodeTo decodes the current frame into the provided Framebuffer.
 // Returns io.EOF when all frames have been decoded.
 // Returns ErrDecodingFailed if the frame cannot be decoded.


### PR DESCRIPTION
Expose specific codec information for video files instead of just container format. Video codecs supported: H264, HEVC, AV1, VP8, VP9, MPEG4 Audio codecs supported: AAC, MP3, FLAC, Vorbis, Opus Returns "Unknown" for unsupported codecs.

- Add VideoCodec() and AudioCodec() methods to Decoder interface
- Implement codec detection in avCodecDecoder using FFmpeg codec IDs
- Add codec methods to all decoder implementations for interface compatibility
- Update example to display codec information
- AVIF reports AV1 video codec, WebP reports VP8 video codec