### PR TITLE
CI: Build on linux/arm64 as well

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -20,6 +20,7 @@ jobs:
         runs-on:
           - macos-15
           - ubuntu-22.04
+          - ubuntu-22.04-arm
       fail-fast: false
     runs-on: ${{ matrix.runs-on }}
     steps:


### PR DESCRIPTION
Now that lilliput [supports arm64 on Linux](https://github.com/discord/lilliput/pull/239) (thank you!), we might as well test it in CI. GitHub has ARM runners [in public preview](https://github.blog/changelog/2025-01-16-linux-arm64-hosted-runners-now-available-for-free-in-public-repositories-public-preview/) that have worked well for other OSS projects.