### PR TITLE
raise acceptable icc size to 32K and refactor into constant

### DIFF
--- a/avcodec.go
+++ b/avcodec.go
@@ -106,7 +106,7 @@ func (d *avCodecDecoder) LoopCount() int {
 
 // ICC returns the ICC color profile data if present, or an empty slice if not.
 func (d *avCodecDecoder) ICC() []byte {
-	iccDst := make([]byte, 8192)
+	iccDst := make([]byte, ICCProfileBufferSize)
 	iccLength := C.avcodec_decoder_get_icc(d.decoder, unsafe.Pointer(&iccDst[0]), C.size_t(cap(iccDst)))
 	if iccLength <= 0 {
 		return []byte{}

--- a/avif.go
+++ b/avif.go
@@ -101,7 +101,7 @@ func (d *avifDecoder) hasReachedEndOfFrames() bool {
 }
 
 func (d *avifDecoder) ICC() []byte {
-	iccDst := make([]byte, 8192)
+	iccDst := make([]byte, ICCProfileBufferSize)
 	iccLength := C.avif_decoder_get_icc(d.decoder, unsafe.Pointer(&iccDst[0]), C.size_t(cap(iccDst)))
 	return iccDst[:iccLength]
 }

--- a/lilliput.go
+++ b/lilliput.go
@@ -9,6 +9,11 @@ import (
 	"time"
 )
 
+const (
+	// ICCProfileBufferSize is the buffer size for ICC color profile data
+	ICCProfileBufferSize = 32768
+)
+
 var (
 	ErrInvalidImage     = errors.New("unrecognized image format")
 	ErrDecodingFailed   = errors.New("failed to decode image")

--- a/opencv.go
+++ b/opencv.go
@@ -684,13 +684,13 @@ func (d *openCVDecoder) ICC() []byte {
 }
 
 func (d *openCVDecoder) iccJPEG() []byte {
-	iccDst := make([]byte, 8192)
+	iccDst := make([]byte, ICCProfileBufferSize)
 	iccLength := C.opencv_decoder_get_jpeg_icc(unsafe.Pointer(&d.buf[0]), C.size_t(len(d.buf)), unsafe.Pointer(&iccDst[0]), C.size_t(cap(iccDst)))
 	return iccDst[:iccLength]
 }
 
 func (d *openCVDecoder) iccPNG() []byte {
-	iccDst := make([]byte, 8192)
+	iccDst := make([]byte, ICCProfileBufferSize)
 	iccLength := C.opencv_decoder_get_png_icc(unsafe.Pointer(&d.buf[0]), C.size_t(len(d.buf)), unsafe.Pointer(&iccDst[0]), C.size_t(cap(iccDst)))
 	return iccDst[:iccLength]
 }

--- a/webp.go
+++ b/webp.go
@@ -98,7 +98,7 @@ func (d *webpDecoder) advanceFrameIndex() {
 
 // ICC returns the ICC color profile data embedded in the WebP image.
 func (d *webpDecoder) ICC() []byte {
-	iccDst := make([]byte, 8192)
+	iccDst := make([]byte, ICCProfileBufferSize)
 	iccLength := C.webp_decoder_get_icc(d.decoder, unsafe.Pointer(&iccDst[0]), C.size_t(cap(iccDst)))
 	return iccDst[:iccLength]
 }


### PR DESCRIPTION
we had a limit of 8k, some reasonably sized profiles were not making it through. Raised the limit to 32k and refactored the buffer size to a shared constant. Ostensibly we can go larger than this, but 32k is going to cover basically everything except for very complicated custom profiles.