### PR TITLE
feat: keyframe index extraction + decoding for spritesheet generation

### DIFF
--- a/avcodec.cpp
+++ b/avcodec.cpp
@@ -1,5 +1,7 @@
 #include "avcodec.hpp"
 
+#include <cstdio>
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -19,6 +21,94 @@ extern "C" {
 #ifdef __cplusplus
 }
 #endif
+
+/* converts a decoded AVFrame (YUV) into a BGRA cv::Mat at the mat's dimensions.
+ * this does four things in a single sws_scale pass:
+ *   1. pixel format conversion — decoded frames are YUV (e.g. YUV420P), but
+ *      cv::Mat and downstream encoders (JPEG/WebP) expect BGRA
+ *   2. scaling — resizes from source dimensions (e.g. 1920x1080) to the
+ *      thumbnail dimensions already set on the output mat
+ *   3. colorspace mapping — selects the correct YUV-to-RGB conversion matrix
+ *      based on the source video's color standard (BT.709 for HD, BT.601 for
+ *      SD, BT.2020 for HDR, etc.) so colors don't shift
+ *   4. stride alignment — pads output rows to 32-byte boundaries, which
+ *      opencv and SIMD operations expect for performance
+ * returns true on success. */
+static bool scale_yuv_frame_to_bgra_mat(AVFrame* frame, opencv_mat output_mat)
+{
+    auto cvMat = static_cast<cv::Mat*>(output_mat);
+    if (!cvMat) {
+        fprintf(stderr, "scale_yuv_frame_to_bgra_mat: output_mat is null\n");
+        return false;
+    }
+
+    /* stride alignment: pad row width to next 32-byte boundary */
+    int stepSize = 4 * cvMat->cols;
+    if (cvMat->cols % 32 != 0) {
+        int width = cvMat->cols + 32 - (cvMat->cols % 32);
+        stepSize = 4 * width;
+    }
+    if (!opencv_mat_set_row_stride(output_mat, stepSize)) {
+        fprintf(stderr, "scale_yuv_frame_to_bgra_mat: failed to set row stride\n");
+        return false;
+    }
+
+    /* set up sws context for format conversion + scaling */
+    struct SwsContext* sws = sws_getContext(
+        frame->width, frame->height, (AVPixelFormat)(frame->format), /* source */
+        cvMat->cols, cvMat->rows, AV_PIX_FMT_BGRA,                  /* destination */
+        SWS_BILINEAR, NULL, NULL, NULL);
+
+    if (!sws) {
+        fprintf(stderr, "scale_yuv_frame_to_bgra_mat: sws_getContext failed\n");
+        return false;
+    }
+
+    /* pick the correct YUV color matrix for this video's standard */
+    int colorspace;
+    switch (frame->colorspace) {
+    case AVCOL_SPC_BT2020_NCL:
+    case AVCOL_SPC_BT2020_CL:
+        colorspace = SWS_CS_BT2020;
+        break;
+    case AVCOL_SPC_BT470BG:
+        colorspace = SWS_CS_ITU601;
+        break;
+    case AVCOL_SPC_SMPTE170M:
+        colorspace = SWS_CS_SMPTE170M;
+        break;
+    case AVCOL_SPC_SMPTE240M:
+        colorspace = SWS_CS_SMPTE240M;
+        break;
+    default:
+        colorspace = SWS_CS_ITU709;
+        break;
+    }
+    const int* inv_table = sws_getCoefficients(colorspace);
+    int srcRange = frame->color_range == AVCOL_RANGE_JPEG ? 1 : 0;
+    const int* table = sws_getCoefficients(SWS_CS_DEFAULT);
+    if (sws_setColorspaceDetails(sws, inv_table, srcRange, table, 1, 0, 1 << 16, 1 << 16) < 0) {
+        fprintf(stderr, "scale_yuv_frame_to_bgra_mat: sws_setColorspaceDetails failed\n");
+        sws_freeContext(sws);
+        return false;
+    }
+
+    int dstLinesizes[4];
+    if (av_image_fill_linesizes(dstLinesizes, AV_PIX_FMT_BGRA, stepSize / 4) < 0) {
+        fprintf(stderr, "scale_yuv_frame_to_bgra_mat: av_image_fill_linesizes failed\n");
+        sws_freeContext(sws);
+        return false;
+    }
+    uint8_t* dstData[4] = {cvMat->data, NULL, NULL, NULL};
+
+    int ret = sws_scale(sws, frame->data, frame->linesize, 0, frame->height, dstData, dstLinesizes);
+    sws_freeContext(sws);
+    if (ret < 0) {
+        fprintf(stderr, "scale_yuv_frame_to_bgra_mat: sws_scale failed\n");
+        return false;
+    }
+    return true;
+}
 
 extern AVInputFormat ff_mov_demuxer;
 extern AVInputFormat ff_matroska_demuxer;
@@ -478,78 +568,11 @@ static int avcodec_decoder_copy_frame(const avcodec_decoder d, opencv_mat mat, A
         return -1;
     }
     
-    auto cvMat = static_cast<cv::Mat*>(mat);
-    if (!cvMat) {
-        return -1;
-    }
-
     int res = avcodec_receive_frame(d->codec, frame);
     if (res >= 0) {
-        // Calculate the step size based on the cv::Mat's width
-        int stepSize =
-          4 * cvMat->cols; // Assuming the cv::Mat is in BGRA format, which has 4 channels
-        if (cvMat->cols % 32 != 0) {
-            int width = cvMat->cols + 32 - (cvMat->cols % 32);
-            stepSize = 4 * width;
-        }
-        if (!opencv_mat_set_row_stride(mat, stepSize)) {
+        if (!scale_yuv_frame_to_bgra_mat(frame, mat)) {
             return -1;
         }
-
-        // Create SwsContext for converting the frame format and scaling
-        struct SwsContext* sws =
-          sws_getContext(frame->width,
-                         frame->height,
-                         (AVPixelFormat)(frame->format), // Source dimensions and format
-                         cvMat->cols,
-                         cvMat->rows,
-                         AV_PIX_FMT_BGRA, // Destination dimensions and format
-                         SWS_BILINEAR,    // Specify the scaling algorithm; you can choose another
-                                          // according to your needs
-                         NULL,
-                         NULL,
-                         NULL);
-
-        // Configure colorspace
-        int colorspace;
-        switch (frame->colorspace) {
-        case AVCOL_SPC_BT2020_NCL:
-        case AVCOL_SPC_BT2020_CL:
-            colorspace = SWS_CS_BT2020;
-            break;
-        case AVCOL_SPC_BT470BG:
-            colorspace = SWS_CS_ITU601;
-            break;
-        case AVCOL_SPC_SMPTE170M:
-            colorspace = SWS_CS_SMPTE170M;
-            break;
-        case AVCOL_SPC_SMPTE240M:
-            colorspace = SWS_CS_SMPTE240M;
-            break;
-        default:
-            colorspace = SWS_CS_ITU709;
-            break;
-        }
-        const int* inv_table = sws_getCoefficients(colorspace);
-
-        // Configure color range
-        int srcRange = frame->color_range == AVCOL_RANGE_JPEG ? 1 : 0;
-
-        // Configure YUV conversion table
-        const int* table = sws_getCoefficients(SWS_CS_DEFAULT);
-
-        sws_setColorspaceDetails(sws, inv_table, srcRange, table, 1, 0, 1 << 16, 1 << 16);
-
-        // The linesizes and data pointers for the destination
-        int dstLinesizes[4];
-        av_image_fill_linesizes(dstLinesizes, AV_PIX_FMT_BGRA, stepSize / 4);
-        uint8_t* dstData[4] = {cvMat->data, NULL, NULL, NULL};
-
-        // Perform the scaling and format conversion
-        sws_scale(sws, frame->data, frame->linesize, 0, frame->height, dstData, dstLinesizes);
-
-        // Free the SwsContext
-        sws_freeContext(sws);
     }
 
     return res;
@@ -618,4 +641,225 @@ void avcodec_decoder_release(avcodec_decoder d)
     }
 
     delete d;
+}
+
+/* ── spritesheet support ──────────────────────────────────────────── */
+
+/* returns the number of keyframes (I-frames) in the video stream's index.
+ * the index is populated by libavformat when it parses the moov atom during
+ * avcodec_decoder_create(). returns -1 on error. */
+int avcodec_decoder_get_keyframe_count(const avcodec_decoder d)
+{
+    if (!d || !d->container) {
+        return -1;
+    }
+
+    if (d->video_stream_index < 0 || d->video_stream_index >= (int)d->container->nb_streams) {
+        return -1;
+    }
+
+    AVStream* st = d->container->streams[d->video_stream_index];
+    int total = avformat_index_get_entries_count(st);
+    int keyframe_count = 0;
+
+    for (int i = 0; i < total; i++) {
+        const AVIndexEntry* e = avformat_index_get_entry(st, i);
+        if (e && (e->flags & AVINDEX_KEYFRAME)) {
+            keyframe_count++;
+        }
+    }
+
+    return keyframe_count;
+}
+
+/* copies keyframe index entries from the moov atom into the caller-provided array.
+ * each entry contains a timestamp, absolute byte offset into mdat, and sample size —
+ * enough to issue an HTTP range request for the raw compressed keyframe data.
+ * returns the number of entries written, or -1 on error. */
+int avcodec_decoder_get_keyframes(
+    const avcodec_decoder d,
+    avcodec_keyframe_entry* out_entries,
+    int max_entries)
+{
+    if (!d || !d->container || !out_entries || max_entries <= 0) {
+        return -1;
+    }
+
+    if (d->video_stream_index < 0 || d->video_stream_index >= (int)d->container->nb_streams) {
+        return -1;
+    }
+
+    AVStream* st = d->container->streams[d->video_stream_index];
+    AVRational time_base = st->time_base;
+    int total = avformat_index_get_entries_count(st);
+    int count = 0;
+
+    for (int i = 0; i < total && count < max_entries; i++) {
+        const AVIndexEntry* e = avformat_index_get_entry(st, i);
+        if (e && (e->flags & AVINDEX_KEYFRAME)) {
+            // h264 streams with B-frames can have a negative initial decode
+            // timestamp due to composition time offsets (the decoder needs to decode
+            // future reference frames before presenting the first frame, so the first
+            // decode timestamp is shifted negative so that the first presentation
+            // timestamp lands at 0).
+            // clamp to 0 since negative timestamps are meaningless for spritesheet
+            // consumers (interval selection, WebVTT generation, tile layout).
+            int64_t ts = av_rescale_q(e->timestamp, time_base, (AVRational){1, 1000000});
+            out_entries[count].timestamp_us = ts < 0 ? 0 : ts;
+            out_entries[count].byte_offset = e->pos;
+            out_entries[count].size = e->size;
+            count++;
+        }
+    }
+
+    return count;
+}
+
+/* returns the AVCodecID for the video stream, as parsed from the moov atom.
+ * needed to create a standalone decoder context for raw keyframe chunks.
+ * returns -1 on error. */
+int avcodec_decoder_get_codec_id(const avcodec_decoder d)
+{
+    if (!d || !d->codec) {
+        return -1;
+    }
+    return (int)d->codec->codec_id;
+}
+
+/* copies the codec extradata from the moov atom (e.g. SPS/PPS for h264) into dest.
+ * this data is required to initialize a standalone decoder for raw keyframe chunks.
+ * pass dest=NULL to query the required buffer size without copying.
+ * returns bytes written, 0 if no extradata, or -1 on error. */
+int avcodec_decoder_get_extradata(
+    const avcodec_decoder d,
+    void* dest,
+    size_t dest_len)
+{
+    if (!d || !d->codec) {
+        return -1;
+    }
+
+    int size = d->codec->extradata_size;
+    if (size <= 0 || !d->codec->extradata) {
+        return 0;
+    }
+
+    if (!dest) {
+        return size;
+    }
+
+    if ((size_t)size > dest_len) {
+        fprintf(stderr, "avcodec_decoder_get_extradata: dest buffer too small (%zu < %d)\n",
+                dest_len, size);
+        return -1;
+    }
+
+    memcpy(dest, d->codec->extradata, size);
+    return size;
+}
+
+/* decodes a single raw keyframe chunk (from a range request) into BGRA pixels.
+ * creates a temporary codec context internally — no demuxer needed, no shared
+ * state, safe for parallel calls across threads.
+ * codec_id, extradata, width, height come from the moov parse phase.
+ * output_mat must be pre-allocated to the desired thumbnail dimensions. */
+bool avcodec_decode_raw_keyframe(
+    int codec_id,
+    const void* extradata,
+    int extradata_size,
+    int source_width,
+    int source_height,
+    const void* chunk_data,
+    int chunk_size,
+    opencv_mat output_mat)
+{
+    if (!chunk_data || chunk_size <= 0 || !output_mat) {
+        fprintf(stderr, "avcodec_decode_raw_keyframe: invalid input (chunk_data=%p, chunk_size=%d)\n",
+                chunk_data, chunk_size);
+        return false;
+    }
+
+    if (extradata && extradata_size > 10 * 1024) {
+        fprintf(stderr, "avcodec_decode_raw_keyframe: extradata too large (%d bytes)\n",
+                extradata_size);
+        return false;
+    }
+
+    const AVCodec* codec = avcodec_find_decoder((AVCodecID)codec_id);
+    if (!codec) {
+        fprintf(stderr, "avcodec_decode_raw_keyframe: no decoder for codec_id=%d\n", codec_id);
+        return false;
+    }
+
+    /* resources that need cleanup -- initialized to NULL so the
+     * cleanup label can free whichever ones were allocated */
+    AVCodecContext* ctx = NULL;
+    AVPacket* pkt = NULL;
+    AVFrame* frame = NULL;
+    bool success = false;
+
+    ctx = avcodec_alloc_context3(codec);
+    if (!ctx) {
+        fprintf(stderr, "avcodec_decode_raw_keyframe: failed to alloc codec context\n");
+        goto cleanup;
+    }
+
+    ctx->width = source_width;
+    ctx->height = source_height;
+
+    if (extradata && extradata_size > 0) {
+        ctx->extradata = (uint8_t*)av_mallocz(extradata_size + AV_INPUT_BUFFER_PADDING_SIZE);
+        if (!ctx->extradata) {
+            fprintf(stderr, "avcodec_decode_raw_keyframe: failed to alloc extradata (%d bytes)\n",
+                    extradata_size);
+            goto cleanup;
+        }
+        memcpy(ctx->extradata, extradata, extradata_size);
+        ctx->extradata_size = extradata_size;
+    }
+
+    if (avcodec_open2(ctx, codec, NULL) < 0) {
+        fprintf(stderr, "avcodec_decode_raw_keyframe: avcodec_open2 failed for codec_id=%d\n",
+                codec_id);
+        goto cleanup;
+    }
+
+    pkt = av_packet_alloc();
+    if (!pkt) {
+        fprintf(stderr, "avcodec_decode_raw_keyframe: failed to alloc packet\n");
+        goto cleanup;
+    }
+    pkt->data = (uint8_t*)chunk_data;
+    pkt->size = chunk_size;
+    pkt->flags = AV_PKT_FLAG_KEY;
+
+    if (avcodec_send_packet(ctx, pkt) < 0) {
+        fprintf(stderr, "avcodec_decode_raw_keyframe: avcodec_send_packet failed\n");
+        goto cleanup;
+    }
+
+    /* flush: signal no more packets so decoder emits the keyframe */
+    avcodec_send_packet(ctx, NULL);
+
+    frame = av_frame_alloc();
+    if (!frame) {
+        fprintf(stderr, "avcodec_decode_raw_keyframe: failed to alloc frame\n");
+        goto cleanup;
+    }
+
+    if (avcodec_receive_frame(ctx, frame) < 0) {
+        fprintf(stderr, "avcodec_decode_raw_keyframe: avcodec_receive_frame failed\n");
+        goto cleanup;
+    }
+
+    success = scale_yuv_frame_to_bgra_mat(frame, output_mat);
+    if (!success) {
+        fprintf(stderr, "avcodec_decode_raw_keyframe: scale_yuv_frame_to_bgra_mat failed\n");
+    }
+
+cleanup:
+    av_frame_free(&frame);
+    av_packet_free(&pkt);
+    avcodec_free_context(&ctx);
+    return success;
 }

--- a/avcodec.cpp
+++ b/avcodec.cpp
@@ -651,10 +651,13 @@ void avcodec_decoder_release(avcodec_decoder d)
 int avcodec_decoder_get_keyframe_count(const avcodec_decoder d)
 {
     if (!d || !d->container) {
+        fprintf(stderr, "avcodec_decoder_get_keyframe_count: decoder or container is null\n");
         return -1;
     }
 
     if (d->video_stream_index < 0 || d->video_stream_index >= (int)d->container->nb_streams) {
+        fprintf(stderr, "avcodec_decoder_get_keyframe_count: invalid video_stream_index=%d\n",
+                d->video_stream_index);
         return -1;
     }
 
@@ -682,10 +685,14 @@ int avcodec_decoder_get_keyframes(
     int max_entries)
 {
     if (!d || !d->container || !out_entries || max_entries <= 0) {
+        fprintf(stderr, "avcodec_decoder_get_keyframes: invalid args (d=%p, out_entries=%p, max_entries=%d)\n",
+                (void*)d, (void*)out_entries, max_entries);
         return -1;
     }
 
     if (d->video_stream_index < 0 || d->video_stream_index >= (int)d->container->nb_streams) {
+        fprintf(stderr, "avcodec_decoder_get_keyframes: invalid video_stream_index=%d\n",
+                d->video_stream_index);
         return -1;
     }
 
@@ -736,6 +743,7 @@ int avcodec_decoder_get_extradata(
     size_t dest_len)
 {
     if (!d || !d->codec) {
+        fprintf(stderr, "avcodec_decoder_get_extradata: decoder or codec context is null\n");
         return -1;
     }
 

--- a/avcodec.go
+++ b/avcodec.go
@@ -4,6 +4,7 @@ package lilliput
 import "C"
 
 import (
+	"errors"
 	"io"
 	"time"
 	"unsafe"
@@ -179,6 +180,121 @@ func (d *avCodecDecoder) Close() {
 	C.avcodec_decoder_release(d.decoder)
 	C.opencv_mat_release(d.mat)
 	d.buf = nil
+}
+
+// KeyframeEntry represents a keyframe from the video's index (moov atom).
+// Contains the timestamp, byte offset into mdat, and compressed size.
+type KeyframeEntry struct {
+	TimestampUs int64
+	ByteOffset  int64
+	Size        int32
+}
+
+// KeyframeCount returns the number of keyframes in the video stream's index.
+func (d *avCodecDecoder) KeyframeCount() (int, error) {
+	count := C.avcodec_decoder_get_keyframe_count(d.decoder)
+	if count < 0 {
+		return 0, errors.New("failed to get keyframe count")
+	}
+	return int(count), nil
+}
+
+// Keyframes returns all keyframe entries from the video stream's index.
+func (d *avCodecDecoder) Keyframes() ([]KeyframeEntry, error) {
+	count, err := d.KeyframeCount()
+	if err != nil {
+		return nil, err
+	}
+	if count == 0 {
+		return nil, nil
+	}
+
+	raw := make([]C.avcodec_keyframe_entry, count)
+	got := C.avcodec_decoder_get_keyframes(d.decoder, &raw[0], C.int(count))
+	if got < 0 {
+		return nil, errors.New("failed to get keyframe entries")
+	}
+
+	entries := make([]KeyframeEntry, int(got))
+	for i := 0; i < int(got); i++ {
+		entries[i] = KeyframeEntry{
+			TimestampUs: int64(raw[i].timestamp_us),
+			ByteOffset:  int64(raw[i].byte_offset),
+			Size:        int32(raw[i].size),
+		}
+	}
+	return entries, nil
+}
+
+// CodecID returns the AVCodecID for the video stream.
+func (d *avCodecDecoder) CodecID() (int, error) {
+	id := C.avcodec_decoder_get_codec_id(d.decoder)
+	if id < 0 {
+		return 0, errors.New("failed to get codec id")
+	}
+	return int(id), nil
+}
+
+// Extradata returns the codec extradata (e.g. SPS/PPS for H.264).
+func (d *avCodecDecoder) Extradata() ([]byte, error) {
+	size := C.avcodec_decoder_get_extradata(d.decoder, nil, 0)
+	if size < 0 {
+		return nil, errors.New("failed to get extradata size")
+	}
+	if size == 0 {
+		return nil, nil
+	}
+
+	buf := make([]byte, int(size))
+	copied := C.avcodec_decoder_get_extradata(d.decoder, unsafe.Pointer(&buf[0]), C.size_t(len(buf)))
+	if copied < 0 {
+		return nil, errors.New("failed to copy extradata")
+	}
+	return buf[:int(copied)], nil
+}
+
+// DecodeRawKeyframe decodes a raw keyframe chunk into BGRA pixels in the provided Framebuffer.
+// The chunk is raw compressed data from the mdat region (via range request).
+// codecID, extradata, sourceWidth, and sourceHeight come from the moov parse phase.
+// thumbWidth and thumbHeight specify the desired output dimensions.
+func DecodeRawKeyframe(codecID int, extradata []byte, sourceWidth, sourceHeight int, chunk []byte, thumbWidth, thumbHeight int, dst *Framebuffer) error {
+	// the C layer aligns output rows to 32-pixel boundaries for SIMD.
+	// ensure the backing buffer is large enough for the padded stride.
+	paddedWidth := thumbWidth
+	if thumbWidth%32 != 0 {
+		paddedWidth = thumbWidth + 32 - (thumbWidth % 32)
+	}
+	requiredSize := paddedWidth * thumbHeight * 4
+	if len(dst.buf) < requiredSize {
+		dst.buf = make([]byte, requiredSize)
+	}
+
+	err := dst.resizeMat(thumbWidth, thumbHeight, PixelType(C.CV_8UC4))
+	if err != nil {
+		return err
+	}
+
+	var extradataPtr unsafe.Pointer
+	extradataSize := C.int(0)
+	if len(extradata) > 0 {
+		extradataPtr = unsafe.Pointer(&extradata[0])
+		extradataSize = C.int(len(extradata))
+	}
+
+	ok := C.avcodec_decode_raw_keyframe(
+		C.int(codecID),
+		extradataPtr,
+		extradataSize,
+		C.int(sourceWidth),
+		C.int(sourceHeight),
+		unsafe.Pointer(&chunk[0]),
+		C.int(len(chunk)),
+		dst.mat,
+	)
+	if !ok {
+		return ErrDecodingFailed
+	}
+	return nil
 }
 
 // init initializes the avcodec library when the package is loaded.

--- a/avcodec.go
+++ b/avcodec.go
@@ -253,19 +253,23 @@ func (d *avCodecDecoder) Extradata() ([]byte, error) {
 	return buf[:int(copied)], nil
 }
 
+// bgraStrideBufSize returns the buffer size needed for a BGRA framebuffer at
+// the given dimensions, accounting for the 32-pixel row stride alignment that
+// the C layer's sws_scale path requires for SIMD.
+func bgraStrideBufSize(width, height int) int {
+	paddedWidth := width
+	if width%32 != 0 {
+		paddedWidth = width + 32 - (width % 32)
+	}
+	return paddedWidth * height * 4
+}
+
 // DecodeRawKeyframe decodes a raw keyframe chunk into BGRA pixels in the provided Framebuffer.
 // The chunk is raw compressed data from the mdat region (via range request).
 // codecID, extradata, sourceWidth, and sourceHeight come from the moov parse phase.
 // thumbWidth and thumbHeight specify the desired output dimensions.
 func DecodeRawKeyframe(codecID int, extradata []byte, sourceWidth, sourceHeight int, chunk []byte, thumbWidth, thumbHeight int, dst *Framebuffer) error {
-	// the C layer aligns output rows to 32-pixel boundaries for SIMD.
-	// ensure the backing buffer is large enough for the padded stride.
-	paddedWidth := thumbWidth
-	if thumbWidth%32 != 0 {
-		paddedWidth = thumbWidth + 32 - (thumbWidth % 32)
-	}
-	requiredSize := paddedWidth * thumbHeight * 4
-	if len(dst.buf) < requiredSize {
+	if requiredSize := bgraStrideBufSize(thumbWidth, thumbHeight); len(dst.buf) < requiredSize {
 		dst.buf = make([]byte, requiredSize)
 	}
 

--- a/avcodec.hpp
+++ b/avcodec.hpp
@@ -25,6 +25,35 @@ const char* avcodec_decoder_get_video_codec(const avcodec_decoder d);
 const char* avcodec_decoder_get_audio_codec(const avcodec_decoder d);
 int avcodec_decoder_get_icc(const avcodec_decoder d, void* dest, size_t dest_len);
 
+typedef struct {
+    int64_t timestamp_us;
+    int64_t byte_offset;
+    int32_t size;
+} avcodec_keyframe_entry;
+
+int avcodec_decoder_get_keyframe_count(const avcodec_decoder d);
+int avcodec_decoder_get_keyframes(
+    const avcodec_decoder d,
+    avcodec_keyframe_entry* out_entries,
+    int max_entries
+);
+int avcodec_decoder_get_codec_id(const avcodec_decoder d);
+int avcodec_decoder_get_extradata(
+    const avcodec_decoder d,
+    void* dest,
+    size_t dest_len
+);
+bool avcodec_decode_raw_keyframe(
+    int codec_id,
+    const void* extradata,
+    int extradata_size,
+    int source_width,
+    int source_height,
+    const void* chunk_data,
+    int chunk_size,
+    opencv_mat output_mat
+);
+
 #ifdef __cplusplus
 }
 #endif

--- a/avcodec_test.go
+++ b/avcodec_test.go
@@ -118,6 +118,204 @@ func TestAV1VideoDecoding(t *testing.T) {
 	}
 }
 
+func TestKeyframeEntries(t *testing.T) {
+	buf, err := os.ReadFile("testdata/big_buck_bunny_480p_10s_std.mp4")
+	if err != nil {
+		t.Fatalf("failed to open test file: %v", err)
+	}
+	dec, err := newAVCodecDecoder(buf)
+	if err != nil {
+		t.Fatalf("failed to create decoder: %v", err)
+	}
+	defer dec.Close()
+
+	entries, err := dec.Keyframes()
+	if err != nil {
+		t.Fatalf("failed to get keyframes: %v", err)
+	}
+	if len(entries) == 0 {
+		t.Fatal("expected keyframe entries")
+	}
+
+	if entries[0].TimestampUs < 0 {
+		t.Fatalf("first keyframe timestamp should be non-negative, got %d", entries[0].TimestampUs)
+	}
+
+	for i, e := range entries {
+		if e.ByteOffset <= 0 {
+			t.Fatalf("keyframe %d byte_offset should be positive, got %d", i, e.ByteOffset)
+		}
+		if e.Size <= 0 {
+			t.Fatalf("keyframe %d size should be positive, got %d", i, e.Size)
+		}
+	}
+
+	for i := 1; i < len(entries); i++ {
+		if entries[i].TimestampUs < entries[i-1].TimestampUs {
+			t.Fatalf("keyframe timestamps should be non-decreasing: kf[%d]=%d < kf[%d]=%d",
+				i, entries[i].TimestampUs, i-1, entries[i-1].TimestampUs)
+		}
+	}
+}
+
+func TestCodecIDAndExtradata(t *testing.T) {
+	buf, err := os.ReadFile("testdata/big_buck_bunny_480p_10s_std.mp4")
+	if err != nil {
+		t.Fatalf("failed to open test file: %v", err)
+	}
+	dec, err := newAVCodecDecoder(buf)
+	if err != nil {
+		t.Fatalf("failed to create decoder: %v", err)
+	}
+	defer dec.Close()
+
+	codecID, err := dec.CodecID()
+	if err != nil {
+		t.Fatalf("failed to get codec id: %v", err)
+	}
+	if codecID <= 0 {
+		t.Fatalf("expected valid codec id, got %d", codecID)
+	}
+
+	extradata, err := dec.Extradata()
+	if err != nil {
+		t.Fatalf("failed to get extradata: %v", err)
+	}
+	if len(extradata) == 0 {
+		t.Fatal("expected non-empty extradata (SPS/PPS)")
+	}
+}
+
+// extractFtypMoov extracts ftyp + moov boxes from an mp4 buffer, stripping mdat.
+// this simulates what a media proxy receives via range requests (moov only, no video data).
+func extractFtypMoov(buf []byte) []byte {
+	var out []byte
+	offset := 0
+	for offset+8 <= len(buf) {
+		boxSize := int(buf[offset])<<24 | int(buf[offset+1])<<16 | int(buf[offset+2])<<8 | int(buf[offset+3])
+		boxType := string(buf[offset+4 : offset+8])
+		if boxSize < 8 || offset+boxSize > len(buf) {
+			break
+		}
+		if boxType == "ftyp" || boxType == "moov" {
+			out = append(out, buf[offset:offset+boxSize]...)
+		}
+		offset += boxSize
+	}
+	return out
+}
+
+func TestMoovOnlyParsing(t *testing.T) {
+	fullBuf, err := os.ReadFile("testdata/big_buck_bunny_480p_10s_std.mp4")
+	if err != nil {
+		t.Fatalf("failed to open test file: %v", err)
+	}
+	moovBuf := extractFtypMoov(fullBuf)
+	if len(moovBuf) >= len(fullBuf) {
+		t.Fatal("moov-only buffer should be smaller than the full file")
+	}
+
+	dec, err := newAVCodecDecoder(moovBuf)
+	if err != nil {
+		t.Fatalf("failed to create decoder from moov-only buffer: %v", err)
+	}
+	defer dec.Close()
+
+	entries, err := dec.Keyframes()
+	if err != nil {
+		t.Fatalf("failed to get keyframes from moov-only buffer: %v", err)
+	}
+	if len(entries) == 0 {
+		t.Fatal("expected keyframes from moov-only buffer")
+	}
+
+	codecID, err := dec.CodecID()
+	if err != nil {
+		t.Fatalf("failed to get codec id from moov-only buffer: %v", err)
+	}
+	if codecID <= 0 {
+		t.Fatalf("expected valid codec id from moov-only buffer, got %d", codecID)
+	}
+
+	extradata, err := dec.Extradata()
+	if err != nil {
+		t.Fatalf("failed to get extradata from moov-only buffer: %v", err)
+	}
+	if len(extradata) == 0 {
+		t.Fatal("expected extradata from moov-only buffer")
+	}
+
+	for i, e := range entries {
+		if e.ByteOffset <= 0 {
+			t.Fatalf("keyframe %d byte_offset should be positive, got %d", i, e.ByteOffset)
+		}
+		if e.Size <= 0 {
+			t.Fatalf("keyframe %d size should be positive, got %d", i, e.Size)
+		}
+	}
+}
+
+func TestDecodeMultipleKeyframes(t *testing.T) {
+	buf, err := os.ReadFile("testdata/big_buck_bunny_480p_10s_std.mp4")
+	if err != nil {
+		t.Fatalf("failed to open test file: %v", err)
+	}
+	dec, err := newAVCodecDecoder(buf)
+	if err != nil {
+		t.Fatalf("failed to create decoder: %v", err)
+	}
+	defer dec.Close()
+
+	header, err := dec.Header()
+	if err != nil {
+		t.Fatalf("failed to get header: %v", err)
+	}
+	codecID, err := dec.CodecID()
+	if err != nil {
+		t.Fatalf("failed to get codec id: %v", err)
+	}
+	extradata, err := dec.Extradata()
+	if err != nil {
+		t.Fatalf("failed to get extradata: %v", err)
+	}
+	entries, err := dec.Keyframes()
+	if err != nil {
+		t.Fatalf("failed to get keyframes: %v", err)
+	}
+
+	thumbW := 160
+	thumbH := int(float64(header.Height()) / float64(header.Width()) * float64(thumbW))
+	if thumbH%2 != 0 {
+		thumbH++
+	}
+
+	toTest := len(entries)
+	if toTest > 5 {
+		toTest = 5
+	}
+	if toTest == 0 {
+		t.Fatal("need at least one keyframe")
+	}
+
+	for i := 0; i < toTest; i++ {
+		kf := entries[i]
+		start := int(kf.ByteOffset)
+		end := start + int(kf.Size)
+		if end > len(buf) {
+			t.Fatalf("keyframe %d range %d..%d exceeds file size %d", i, start, end, len(buf))
+		}
+		chunk := buf[start:end]
+
+		fb := NewFramebuffer(thumbW, thumbH)
+		err := DecodeRawKeyframe(codecID, extradata, header.Width(), header.Height(), chunk, thumbW, thumbH, fb)
+		fb.Close()
+		if err != nil {
+			t.Fatalf("keyframe %d (t=%dus, offset=%d, size=%d) failed to decode: %v",
+				i, kf.TimestampUs, kf.ByteOffset, kf.Size, err)
+		}
+	}
+}
+
 func BenchmarkIsStreamableWebMp4(b *testing.B) {
 	// Read the web-optimized streamable MP4 file
 	webMp4, err := os.ReadFile("testdata/big_buck_bunny_480p_10s_web.mp4")


### PR DESCRIPTION
## summary
this PR adds the foundation for video spritesheet generation (for video player scrubbing previews). specifically, extracting keyframe positions from an mp4's moov atom and decoding individual keyframes into thumbnails without needing a full demux pass.

overall strategy:
  1. parse the mp4 container's moov atom to build a keyframe index (byte offsets, timestamps, sizes)
  2. fetch individual compressed keyframes -- either via HTTP range requests against remote storage or by slicing into a
  locally-buffered file
  3. decode each keyframe independently into a thumbnail
  4. compose the thumbnails into a tile grid and encode as a single image (e.g. WebP)

  this PR implements the lilliput primitives for steps 1 and 3 -- the codec-level building blocks that the higher-level
  spritesheet pipeline will call into. 
  
  the moov atom contains everything needed to build the keyframe index (sample tables, chunk offsets, sync sample list), so the full video doesn't need to be downloaded or demuxed just to figure out where the keyframes are. and because keyframes are self-contained (they don't depend on other frames for decoding), each one can be decoded in isolation with just the codec extradata (e.g. h264 SPS/PPS) and the raw compressed bytes.
  
  of course, this is less important for super short vids but hey 
