### PR TITLE
[bug] fix giflib OOB heap read

### DIFF
--- a/giflib.cpp
+++ b/giflib.cpp
@@ -521,6 +521,10 @@ static bool giflib_decoder_render_frame(giflib_decoder d, GraphicsControlBlock* 
                 dst += 4;
                 continue;
             }
+            if (palette_index >= colorMap->ColorCount) {
+                dst += 4;
+                continue;
+            }
             *dst++ = colorMap->Colors[palette_index].Blue;
             *dst++ = colorMap->Colors[palette_index].Green;
             *dst++ = colorMap->Colors[palette_index].Red;


### PR DESCRIPTION
## Summary

Adds a bounds check on GIF palette indices before accessing `colorMap->Colors[]` in the giflib decoder. Without this check, a crafted GIF with pixel indices exceeding the color table size causes an out-of-bounds heap read — the read data (3 bytes per pixel: R, G, B) flows into the output image, leaking heap memory contents to the caller.

The fix is at `giflib.cpp:524`. Pixels with out-of-bounds palette indices are now skipped (treated as transparent), matching the existing behavior for transparency index pixels.
