### PR TITLE
fix libpng include path

### DIFF
--- a/opencv.cpp
+++ b/opencv.cpp
@@ -4,7 +4,7 @@
 #include <opencv2/highgui.hpp>
 #include <opencv2/imgproc.hpp>
 #include <jpeglib.h>
-#include <png.h>
+#include <libpng16/png.h>
 #include <setjmp.h>
 #include <iostream>
 


### PR DESCRIPTION
Without the libpng16/ prefix, the png.h cannot be found when compiling on linux, as the png*.h files do not exist directly in include/ but in include/libpng16.
Strangely for osx deps the .h files are duplicated both at the root of the include/ dir and in include/libpng16.