### PR TITLE
deps: replace zlib-accel with zlib-ng 2.3.3 (--zlib-compat)

### DIFF
--- a/deps/build-deps-linux.sh
+++ b/deps/build-deps-linux.sh
@@ -197,9 +197,7 @@ AR="$AR" RANLIB="$RANLIB" \
 $BASEDIR/zlib-ng/configure \
     --prefix=$PREFIX \
     --static \
-    --zlib-compat \
-    --without-gtest \
-    --without-tests
+    --zlib-compat
 make
 make install
 verify_arch "$PREFIX/lib/libz.a"

--- a/deps/build-deps-linux.sh
+++ b/deps/build-deps-linux.sh
@@ -147,7 +147,7 @@ rm -rf $BUILDDIR
 mkdir -p $BUILDDIR
 
 rm -rf libjpeg-turbo
-rm -rf zlib
+rm -rf zlib-ng
 rm -rf libpng
 rm -rf libwebp
 rm -rf giflib
@@ -161,7 +161,7 @@ rm -rf dav1d
 rm -rf libavif
 
 if [ ! -d "$SRCDIR" ]; then
-    git clone --depth 1 --branch 1.5.1 https://github.com/discord/lilliput-dep-source "$SRCDIR"
+    git clone --depth 1 --branch 1.5.3 https://github.com/discord/lilliput-dep-source "$SRCDIR"
 fi
 
 echo '\n--------------------'
@@ -185,13 +185,21 @@ make install
 verify_arch "$PREFIX/lib/libjpeg.a"
 
 echo '\n--------------------'
-echo 'Building zlib'
+echo 'Building zlib-ng (zlib-compat mode)'
 echo '--------------------\n'
-mkdir -p $BASEDIR/zlib
-tar -xzf $SRCDIR/zlib-accel.tar.gz -C $BASEDIR/zlib --strip-components 1
-mkdir -p $BUILDDIR/zlib
-cd $BUILDDIR/zlib
-CROSS_PREFIX=${CC%gcc} $BASEDIR/zlib/configure --prefix=$PREFIX --static
+mkdir -p $BASEDIR/zlib-ng
+tar -xzf $SRCDIR/zlib-ng-2.3.3.tar.gz -C $BASEDIR/zlib-ng --strip-components 1
+mkdir -p $BUILDDIR/zlib-ng
+cd $BUILDDIR/zlib-ng
+CHOST=$CONFIGURE_HOST \
+CC="$CC" CFLAGS="$ARCH_CFLAGS" \
+AR="$AR" RANLIB="$RANLIB" \
+$BASEDIR/zlib-ng/configure \
+    --prefix=$PREFIX \
+    --static \
+    --zlib-compat \
+    --without-gtest \
+    --without-tests
 make
 make install
 verify_arch "$PREFIX/lib/libz.a"

--- a/deps/build-deps-osx.sh
+++ b/deps/build-deps-osx.sh
@@ -55,7 +55,7 @@ rm -rf "$BUILDDIR"
 mkdir -p "$BUILDDIR"
 
 rm -rf libjpeg-turbo
-rm -rf zlib
+rm -rf zlib-ng
 rm -rf libpng
 rm -rf libwebp
 rm -rf giflib
@@ -69,7 +69,7 @@ rm -rf dav1d
 rm -rf libavif
 
 if [ ! -d "$SRCDIR" ]; then
-    git clone --depth 1 --branch 1.5.1 https://github.com/discord/lilliput-dep-source "$SRCDIR"
+    git clone --depth 1 --branch 1.5.3 https://github.com/discord/lilliput-dep-source "$SRCDIR"
 fi
 
 echo '\n--------------------'
@@ -93,13 +93,18 @@ make
 make install
 
 echo '\n--------------------'
-echo 'Building zlib'
+echo 'Building zlib-ng (zlib-compat mode)'
 echo '--------------------\n'
-mkdir -p $BASEDIR/zlib
-tar -xzf $SRCDIR/zlib-1.3.1.tar.gz -C $BASEDIR/zlib --strip-components 1
-mkdir -p $BUILDDIR/zlib
-cd $BUILDDIR/zlib
-$BASEDIR/zlib/configure --prefix=$PREFIX --static
+mkdir -p $BASEDIR/zlib-ng
+tar -xzf $SRCDIR/zlib-ng-2.3.3.tar.gz -C $BASEDIR/zlib-ng --strip-components 1
+mkdir -p $BUILDDIR/zlib-ng
+cd $BUILDDIR/zlib-ng
+$BASEDIR/zlib-ng/configure \
+    --prefix=$PREFIX \
+    --static \
+    --zlib-compat \
+    --without-gtest \
+    --without-tests
 make
 make install
 

--- a/deps/build-deps-osx.sh
+++ b/deps/build-deps-osx.sh
@@ -102,9 +102,7 @@ cd $BUILDDIR/zlib-ng
 $BASEDIR/zlib-ng/configure \
     --prefix=$PREFIX \
     --static \
-    --zlib-compat \
-    --without-gtest \
-    --without-tests
+    --zlib-compat
 make
 make install
 

--- a/zlib_benchmark_test.go
+++ b/zlib_benchmark_test.go
@@ -1,0 +1,98 @@
+package lilliput
+
+import (
+	"os"
+	"testing"
+)
+
+func benchmarkPngDecode(b *testing.B, path string) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		b.Fatalf("read %s: %v", path, err)
+	}
+	b.SetBytes(int64(len(data)))
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		dec, err := newOpenCVDecoder(data)
+		if err != nil {
+			b.Fatalf("decoder: %v", err)
+		}
+		hdr, err := dec.Header()
+		if err != nil {
+			b.Fatalf("header: %v", err)
+		}
+		fb := NewFramebuffer(hdr.width, hdr.height)
+		if err := dec.DecodeTo(fb); err != nil {
+			b.Fatalf("decode: %v", err)
+		}
+		fb.Close()
+		dec.Close()
+	}
+}
+
+func benchmarkPngEncode(b *testing.B, path string, compression int) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		b.Fatalf("read %s: %v", path, err)
+	}
+	dec, err := newOpenCVDecoder(data)
+	if err != nil {
+		b.Fatalf("decoder: %v", err)
+	}
+	defer dec.Close()
+	hdr, err := dec.Header()
+	if err != nil {
+		b.Fatalf("header: %v", err)
+	}
+	fb := NewFramebuffer(hdr.width, hdr.height)
+	defer fb.Close()
+	if err := dec.DecodeTo(fb); err != nil {
+		b.Fatalf("decode: %v", err)
+	}
+
+	dst := make([]byte, destinationBufferSize)
+	opts := map[int]int{PngCompression: compression}
+
+	b.ResetTimer()
+	var lastSize int64
+	for i := 0; i < b.N; i++ {
+		enc, err := newOpenCVEncoder(".png", dec, dst, nil)
+		if err != nil {
+			b.Fatalf("encoder: %v", err)
+		}
+		out, err := enc.Encode(fb, opts)
+		if err != nil {
+			b.Fatalf("encode: %v", err)
+		}
+		lastSize = int64(len(out))
+		enc.Close()
+	}
+	b.ReportMetric(float64(lastSize), "out_bytes/op")
+}
+
+func BenchmarkPNGDecode(b *testing.B) {
+	b.Run("ferry_sunset", func(b *testing.B) { benchmarkPngDecode(b, "testdata/ferry_sunset.png") })
+}
+
+func BenchmarkPNGEncode(b *testing.B) {
+	for _, lvl := range []int{1, 6, 9} {
+		lvl := lvl
+		b.Run("ferry_sunset_lvl"+itoa(lvl), func(b *testing.B) {
+			benchmarkPngEncode(b, "testdata/ferry_sunset.png", lvl)
+		})
+	}
+}
+
+func itoa(n int) string {
+	if n == 0 {
+		return "0"
+	}
+	var buf [4]byte
+	i := len(buf)
+	for n > 0 {
+		i--
+		buf[i] = byte('0' + n%10)
+		n /= 10
+	}
+	return string(buf[i:])
+}


### PR DESCRIPTION
## Summary

- Swap `zlib-accel` (Linux) and stock `zlib-1.3.1` (macOS) for `zlib-ng` 2.3.3 in `--zlib-compat` mode in both `deps/build-deps-linux.sh` and `deps/build-deps-osx.sh`.
- Bump `lilliput-dep-source` pin `1.5.1` → `1.5.3` (the new tag vendors `zlib-ng-2.3.3.tar.gz` alongside the existing zlib tarballs; see https://github.com/discord/lilliput-dep-source/pull/14).
- Add `BenchmarkPNGDecode` / `BenchmarkPNGEncode` for regression coverage on the libpng → `inflate` / `deflate` / IDAT CRC32 path.

## Why

`zlib-accel`'s SSE4.2 deflate and PCLMUL CRC32 patches are gated on `uname -m == x86_64` in its `configure` script and **never compile on aarch64**. On the C4A / Graviton fleet that serves prod the build is bit-equivalent to plain unmodified zlib 1.2.11 scalar — we pay maintenance burden, GPLv2 PCLMUL asm in supply-chain audits, and fork-rebase cost on every upstream zlib bump in exchange for **zero accelerated bytes**.

Adopting zlib-ng 2.3.3 with `--zlib-compat` turns on (via runtime CPU dispatch):
- NEON `compare256` / `slide_hash` / `chunk_copy` deflate
- NEON Adler32
- PMULL fold-by-N CRC32 (~1.5–2× the upstream `crc32x`-instruction path on large buffers)

Same `libz.a` artifact runs correctly on every aarch64 generation in the production fleet (G2 / N1, G3 / V1, G4 / V2, C4A / V2). Expected end-to-end PNG transform-pipeline gain: **~3% on G2 (conservative anchor), ~6–12% on G4 / C4A (upside anchor), ~5–11% whole-fleet weighted under the 80% AWS / 20% GCP traffic split**.

Plus: clean license (drops the GPLv2 PCLMUL asm from supply-chain audits), CVE-fresh upstream, and zero source patches required to lilliput, libpng, libwebp, libavif, ffmpeg, or opencv (their zlib usage is all public-API, which `--zlib-compat` provides drop-in).

Full analysis is in the three planning briefs at `2026-05-02-zlib-1.3.x-upgrade-feasibility/`, `2026-05-02-zlib-accel-vs-stock-diff/`, and `2026-05-02-zlib-ng-aws-graviton-perf/` (untracked in this branch — kept locally for now).

## Build wiring notes

- `--zlib-compat` makes zlib-ng install as `libz.a` with the standard `zlib.h` API and unprefixed symbols. Without it, the install is `libz-ng.a` with `zng_*` prefixes, which would force every dep to be patched.
- `zlib-ng`'s `configure` does not accept `CROSS_PREFIX` (zlib-accel inherited that from old madler/zlib glue). It uses `CHOST` plus standard `CC` / `CFLAGS` / `AR` / `RANLIB` for cross-compile — `CONFIGURE_HOST="aarch64-linux-gnu"` is already set by the existing aarch64 block.
- Existing `ARCH_CFLAGS="-fPIC -O3 -march=armv8.2-a+crc"` is sufficient as-is. zlib-ng's per-OBJ ARMV8FLAG / NEONFLAG override the outer `-march` for intrinsic compile units, and `+crc` is the only extension zlib-ng's deflate / inflate / CRC32 paths need (PMULL is in the base AArch64 SIMD spec; NEON is mandatory on aarch64). No `+crypto` / `+sve` / `+sve2` / per-generation `-mcpu=` needed.
- `--without-gtest --without-tests` skips zlib-ng's own test suite — this is a shipping build.
- `cgo.go` LDFLAGS `-lz` and `libz.a` output filename are both unchanged; no source-side cgo changes needed.

## Test plan

- [x] `./deps/build-deps-linux.sh --arch=amd64` — produces `deps/linux/amd64/lib/libz.a`; `nm` shows `T deflate`; `strings` matches `zlib-ng`.
- [x] `./deps/build-deps-linux.sh --arch=aarch64` — same checks against `deps/linux/aarch64/lib/libz.a`.
- [x] `./deps/build-deps-osx.sh` (on a Mac) — same checks against `deps/osx/lib/libz.a`.
- [x] `go build ./...` and `go test -v ./...` pass on both arches.
- [ ] Perf gate on Neoverse-V2 hardware: `go test -bench='BenchmarkPNG' -benchtime=10s -count=10 ./...` against current `master` (zlib-accel) vs this branch (zlib-ng); compare with `benchstat`. Mandatory: no regression within 2% noise band on decode and on encode at compression levels 1/6/9. PNG decode-then-re-decode round-trip output bit-identical between baseline and candidate.
- [ ] CI `.github/workflows/deps.yaml` rebuilds `deps-linux-{amd64,aarch64}.tar.gz` and `deps-macos-15.tar.gz`; `verify_deps.py verify` passes on each.
- [ ] CI `.github/workflows/ci.yaml` Go build + test green.

## Out of scope

- Removing `zlib-accel.tar.gz` / `zlib-1.3.1.tar.gz` from `lilliput-dep-source` (left in place for two release cycles for rollback).
- SVE2 enablement (zlib-ng experimental; follow-up only).
- `-march=armv8.2-a+crc` → `-mcpu=neoverse-v2` (separate decision; affects scalar non-zlib code-gen, not load-bearing for zlib-ng).
