### PR TITLE
Add `Framebuffer.Crop` for arbitrary-rectangle cropping

### DIFF
--- a/crop.go
+++ b/crop.go
@@ -1,0 +1,40 @@
+package lilliput
+
+// #include "opencv.hpp"
+import "C"
+
+import (
+	"errors"
+	"image"
+)
+
+// Crop extracts the rectangular sub-region described by rect and writes the
+// result into dst, without resizing. rect is clamped to the framebuffer
+// bounds. dst must have been created (via NewFramebuffer) large enough to hold
+// rect's dimensions; its contents are replaced.
+//
+// Unlike Fit, which performs a centre crop towards a target aspect ratio, Crop
+// extracts an arbitrary, caller-positioned rectangle.
+func (f *Framebuffer) Crop(rect image.Rectangle, dst *Framebuffer) error {
+	if f == nil || f.mat == nil {
+		return ErrFrameBufNoPixels
+	}
+	if dst == nil {
+		return errors.New("lilliput: Crop destination framebuffer is nil")
+	}
+	rect = rect.Intersect(image.Rect(0, 0, f.width, f.height))
+	w, h := rect.Dx(), rect.Dy()
+	if w < 1 || h < 1 {
+		return errors.New("lilliput: crop rectangle is empty or outside the image")
+	}
+	cropped := C.opencv_mat_crop(f.mat, C.int(rect.Min.X), C.int(rect.Min.Y), C.int(w), C.int(h))
+	if cropped == nil {
+		return errors.New("lilliput: opencv_mat_crop returned nil")
+	}
+	defer C.opencv_mat_release(cropped)
+	if err := dst.resizeMat(w, h, f.pixelType); err != nil {
+		return err
+	}
+	C.opencv_mat_resize(cropped, dst.mat, C.int(w), C.int(h), C.CV_INTER_AREA)
+	return nil
+}


### PR DESCRIPTION
## Summary

Adds `Framebuffer.Crop(rect image.Rectangle, dst *Framebuffer) error` — extracts an arbitrary, caller-positioned rectangle from a framebuffer.

Today the only crop available is `Framebuffer.Fit`, which performs a centre crop towards a target aspect ratio. Callers that need a *specific* region have no public API for it, even though the package already exposes the internal `opencv_mat_crop` primitive (used inside `Fit`). `Crop` surfaces that primitive directly.

## Behaviour

- `rect` is clamped to the framebuffer bounds.
- `dst` is resized to the crop dimensions; its previous contents are replaced.
- No resampling — output pixels equal the source region. It is the same two-step `opencv_mat_crop` → `opencv_mat_resize` that `Fit` already uses internally, with the resize being identity (target size == crop size).
- No new dependencies.

## Verification

Build-verified against `master` (CGO, `linux/amd64`).

The existing `*_test.go` files are parser-focused and there's no decode→`Framebuffer` transform harness to extend, so I kept this change to just the new method to stay self-contained. Happy to add a test if you'd like one — just let me know the harness you'd prefer.